### PR TITLE
Set state class to 'Measurement' where it makes sense

### DIFF
--- a/custom_components/bluetti/sensor.py
+++ b/custom_components/bluetti/sensor.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from homeassistant.const import PERCENTAGE
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
@@ -23,7 +25,15 @@ from .icon_config import get_icon_for_fn_code
 #     },
 # }
 
-SENSOR_MAP = {
+class BaseSensorMetaInfo(TypedDict):
+    device_class: SensorDeviceClass
+    state_class: SensorStateClass | None
+    unit: str | None
+    
+class NamedSensorMetaInfo(BaseSensorMetaInfo):
+    name: str
+    
+SENSOR_MAP: dict[str, BaseSensorMetaInfo] = {
     "SensorDeviceClass.BATTERY":{
         "device_class":SensorDeviceClass.BATTERY,
         "state_class":SensorStateClass.MEASUREMENT,
@@ -31,12 +41,12 @@ SENSOR_MAP = {
     },
     "SensorDeviceClass.ENUM":{
         "device_class":SensorDeviceClass.ENUM,
-        "state_class": "",
-        "unit": ""
+        "state_class": None,
+        "unit": None
     },
     "SensorDeviceClass.DURATION":{
         "device_class":SensorDeviceClass.DURATION,
-        "state_class": "",
+        "state_class": None,
         "unit": "min"
     },
     "SensorDeviceClass.POWER":{
@@ -77,7 +87,7 @@ async def async_setup_entry(
         for state in device.states:
             if state.fn_type == 'SENSOR' and state.sensor_info:
                 sensorClass = SENSOR_MAP[state.sensor_info['sensorType']]
-                meta = {
+                meta: NamedSensorMetaInfo = {
                     "name": state.fn_name,
                     "unit": state.sensor_info["unit"] or sensorClass["unit"],
                     "device_class": sensorClass["device_class"],
@@ -99,16 +109,16 @@ class BluettiSensor(SensorEntity):
 
     # should_poll = True
 
-    def __init__(self, device: BluettiDevice, state: BluettiState, meta: dict):
+    def __init__(self, device: BluettiDevice, state: BluettiState, meta: NamedSensorMetaInfo):
         self._device = device
         self._state_obj = state
         self._meta = meta
 
         self._attr_unique_id = f"{device.device_id}_{state.fn_code}"
         self._attr_name = f"{device.name} {meta['name']}"
-        self._attr_device_class = meta.get("device_class")
-        self._attr_state_class = meta.get("state_class")
-        self._attr_native_unit_of_measurement = meta.get("unit")
+        self._attr_device_class = meta["device_class"]
+        self._attr_state_class = meta["state_class"]
+        self._attr_native_unit_of_measurement = meta["unit"]
         self._attr_icon = get_icon_for_fn_code(state.fn_code)
         self._attr_device_info = {
             "identifiers": {(DOMAIN, device.device_id)},  # 唯一ID

--- a/custom_components/bluetti/sensor.py
+++ b/custom_components/bluetti/sensor.py
@@ -31,10 +31,12 @@ SENSOR_MAP = {
     },
     "SensorDeviceClass.ENUM":{
         "device_class":SensorDeviceClass.ENUM,
+        "state_class": "",
         "unit": ""
     },
     "SensorDeviceClass.DURATION":{
         "device_class":SensorDeviceClass.DURATION,
+        "state_class": "",
         "unit": "min"
     },
     "SensorDeviceClass.POWER":{
@@ -75,8 +77,13 @@ async def async_setup_entry(
         for state in device.states:
             if state.fn_type == 'SENSOR' and state.sensor_info:
                 sensorClass = SENSOR_MAP[state.sensor_info['sensorType']]
-                meta = {'name':state.fn_name,'unit': state.sensor_info['unit'] or sensorClass['unit'],'device_class':sensorClass['device_class']}
-                entities.append(BluettiSensor(device, state,meta))
+                meta = {
+                    "name": state.fn_name,
+                    "unit": state.sensor_info["unit"] or sensorClass["unit"],
+                    "device_class": sensorClass["device_class"],
+                    "state_class": sensorClass["state_class"]
+                }
+                entities.append(BluettiSensor(device, state, meta))
             if state.fn_type == "SENSOR" and state.fn_code in BINARY_SENSOR_MAP:
                 entities.append(BluettiBinarySensor(device, state, BINARY_SENSOR_MAP[state.fn_code]))
 
@@ -100,6 +107,7 @@ class BluettiSensor(SensorEntity):
         self._attr_unique_id = f"{device.device_id}_{state.fn_code}"
         self._attr_name = f"{device.name} {meta['name']}"
         self._attr_device_class = meta.get("device_class")
+        self._attr_state_class = meta.get("state_class")
         self._attr_native_unit_of_measurement = meta.get("unit")
         self._attr_icon = get_icon_for_fn_code(state.fn_code)
         self._attr_device_info = {

--- a/custom_components/bluetti/sensor.py
+++ b/custom_components/bluetti/sensor.py
@@ -1,5 +1,5 @@
 from homeassistant.const import PERCENTAGE
-from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -26,6 +26,7 @@ from .icon_config import get_icon_for_fn_code
 SENSOR_MAP = {
     "SensorDeviceClass.BATTERY":{
         "device_class":SensorDeviceClass.BATTERY,
+        "state_class":SensorStateClass.MEASUREMENT,
         "unit": PERCENTAGE
     },
     "SensorDeviceClass.ENUM":{
@@ -38,6 +39,7 @@ SENSOR_MAP = {
     },
     "SensorDeviceClass.POWER":{
         "device_class":SensorDeviceClass.POWER,
+        "state_class":SensorStateClass.MEASUREMENT,
         "unit": "W"
     }
 }


### PR DESCRIPTION
Use measurement state class for power and battery capacity sensors.

This fixes sensor availability in the energy dashboard and is just a nice thing to have properly set.