### PR TITLE
Refresh OAuth token automatically on expiry instead of only showing "OAuth Expired"

### DIFF
--- a/custom_components/bluetti/oauth.py
+++ b/custom_components/bluetti/oauth.py
@@ -184,9 +184,9 @@ class AuthTokenRefresh:
         unsub = hass.bus.async_listen(EVENT_TOKEN_EXPIRED, self.on_token_expired_event)
         entry.async_on_unload(unsub)
 
-    async def on_token_expired_event(self,event):
-        __LOGGER__.info("on_token_expired_event")
-        self.send_expired_notification()
+    async def on_token_expired_event(self, event):
+        __LOGGER__.info("on_token_expired_event, try to refresh token")
+        await self.async_check_token_expiry(force_or_now=True)
 
     def start_token_check(self):
         # first clear old notify
@@ -239,30 +239,50 @@ class AuthTokenRefresh:
         )
 
     # check token is in 7 day if in 7day refesh token
-    async def async_check_token_expiry(self):
-        __LOGGER__.info("check token is expired")
-        expire_timestamp = cast(float, self.oAuth2Session.token["expires_at"])
-        current_timestamp = time.time()
-        remain_timestamp = expire_timestamp - current_timestamp
-        if remain_timestamp < 0:
+    async def async_check_token_expiry(self, force_or_now=False):
+        # `force_or_now` is a bool when called explicitly, or a datetime when
+        # invoked by async_track_time_interval; only the bool means "force".
+        force = force_or_now if isinstance(force_or_now, bool) else False
+        __LOGGER__.info(f"check token is expired (force={force})")
+        token = self.oAuth2Session.token
+        if not token:
             self.send_expired_notification()
             return
-        
-        if remain_timestamp < 3600*24*7 :
+
+        expire_timestamp = 0.0
+        if "expires_at" in token:
+            expire_timestamp = cast(float, token["expires_at"])
+        elif "expires_in" in token and "created_at" in token:
+            expire_timestamp = cast(float, token["created_at"]) + cast(float, token["expires_in"])
+
+        current_timestamp = time.time()
+        remain_timestamp = expire_timestamp - current_timestamp
+
+        # Only give up (and notify) when we are NOT forcing a refresh. A forced
+        # refresh still tries to redeem the refresh_token even past expiry.
+        if not force and remain_timestamp < 0:
+            self.send_expired_notification()
+            return
+
+        if force or remain_timestamp < 3600*24*7:
             try:
                 __LOGGER__.info('start refresh token')
                 last_refesh = self.entry.data.get("last_token_refresh", 0.0)
                 # 1 hour only one time ,when server is 500 do not always refesh token
-                if current_timestamp - last_refesh < 3600 : 
+                if not force and current_timestamp - last_refesh < 3600:
                     __LOGGER__.info('last refesh token in 1 hour,this do not refesh return')
                     return
                 last_refesh = current_timestamp
 
                 new_token = await self.oAuth2Session.implementation.async_refresh_token(self.oAuth2Session.token)
                 self.hass.config_entries.async_update_entry(
-                    self.entry, data={**self.entry.data, "token": new_token,"last_token_refresh":last_refesh}
+                    self.entry, data={**self.entry.data, "token": new_token, "last_token_refresh": last_refesh}
                 )
                 __LOGGER__.info('refresh token ok,then reload')
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
             except Exception as e:
                 __LOGGER__.error(f"refresh token failed: {e}")
+                # Only surface the "OAuth Expired" notice when the refresh truly
+                # failed on an expired/force path, not for transient errors.
+                if force or remain_timestamp < 0:
+                    self.send_expired_notification()

--- a/custom_components/bluetti/oauth.py
+++ b/custom_components/bluetti/oauth.py
@@ -181,6 +181,9 @@ class AuthTokenRefresh:
         self.hass = hass
         self.entry = entry
         self.oAuth2Session = oauth_session
+        # Single-flight guard so a periodic check and an EVENT_TOKEN_EXPIRED
+        # arriving together can't run overlapping refresh+reload cycles.
+        self._refresh_lock = asyncio.Lock()
         unsub = hass.bus.async_listen(EVENT_TOKEN_EXPIRED, self.on_token_expired_event)
         entry.async_on_unload(unsub)
 
@@ -249,6 +252,7 @@ class AuthTokenRefresh:
             self.send_expired_notification()
             return
 
+        has_expiry = "expires_at" in token or ("expires_in" in token and "created_at" in token)
         expire_timestamp = 0.0
         if "expires_at" in token:
             expire_timestamp = cast(float, token["expires_at"])
@@ -257,32 +261,45 @@ class AuthTokenRefresh:
 
         current_timestamp = time.time()
         remain_timestamp = expire_timestamp - current_timestamp
+        # A token with no usable expiry fields must not be treated as expired:
+        # try to refresh it rather than raising a false "expired" notice.
+        truly_expired = has_expiry and remain_timestamp < 0
 
-        # Only give up (and notify) when we are NOT forcing a refresh. A forced
-        # refresh still tries to redeem the refresh_token even past expiry.
-        if not force and remain_timestamp < 0:
+        # Only give up (and notify) when the access token is genuinely past
+        # expiry and we are not forcing a refresh.
+        if not force and truly_expired:
             self.send_expired_notification()
             return
 
-        if force or remain_timestamp < 3600*24*7:
+        # Refresh when forced, when expiry is unknown, or inside the 7-day window.
+        if not (force or not has_expiry or remain_timestamp < 3600*24*7):
+            return
+
+        async with self._refresh_lock:
+            # Re-read after acquiring the lock: a concurrent caller may have just
+            # refreshed. Keep a minimum interval even when forced so a burst of
+            # duplicate events can't trigger repeated refresh+reload cycles.
+            last_refesh = self.entry.data.get("last_token_refresh", 0.0)
+            now = time.time()
+            min_interval = 60 if force else 3600
+            if now - last_refesh < min_interval:
+                __LOGGER__.info(
+                    "token refreshed %.0fs ago (min interval %ss), skipping refresh",
+                    now - last_refesh, min_interval,
+                )
+                return
             try:
                 __LOGGER__.info('start refresh token')
-                last_refesh = self.entry.data.get("last_token_refresh", 0.0)
-                # 1 hour only one time ,when server is 500 do not always refesh token
-                if not force and current_timestamp - last_refesh < 3600:
-                    __LOGGER__.info('last refesh token in 1 hour,this do not refesh return')
-                    return
-                last_refesh = current_timestamp
-
                 new_token = await self.oAuth2Session.implementation.async_refresh_token(self.oAuth2Session.token)
                 self.hass.config_entries.async_update_entry(
-                    self.entry, data={**self.entry.data, "token": new_token, "last_token_refresh": last_refesh}
+                    self.entry, data={**self.entry.data, "token": new_token, "last_token_refresh": now}
                 )
                 __LOGGER__.info('refresh token ok,then reload')
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
-            except Exception as e:
-                __LOGGER__.error(f"refresh token failed: {e}")
+            except Exception:
+                __LOGGER__.exception("refresh token failed")
                 # Only surface the "OAuth Expired" notice when the refresh truly
-                # failed on an expired/force path, not for transient errors.
-                if force or remain_timestamp < 0:
+                # failed on an expired/forced path, not for transient errors or a
+                # merely-missing expiry field.
+                if force or truly_expired:
                     self.send_expired_notification()


### PR DESCRIPTION
## Problem

Users repeatedly get a persistent **"OAuth Expired"** notification that does not go away even after re‑authenticating. The integration keeps polling fine / sensors stay populated, but the auth watchdog keeps firing the expiry notice, and `Reconfigure` only helps for a few seconds/minutes before it returns.

Reported in:
- #75 – *OAuth Expired* ("reports OAuth Expired every 10 minutes, re‑authorizing does not help")
- #81 – *Persistent "OAuth Expired" notification … despite active data session (v1.0.1/v1.0.2)* ("the authentication watchdog seems to misinterpret the token status")
- #97 – *Repeated OAuth Expired notifications* ("reconfigure … relog … receive the same OAuth Expired again within seconds")

## Root cause

The token‑refresh logic never actually redeems the `refresh_token` once the access token is reported expired — it only notifies.

**In `main` (`oauth.py`):**
- `on_token_expired_event` (fired when the cloud returns code `805` = token expired) just calls `send_expired_notification()`. It never attempts a refresh.
- `async_check_token_expiry()` bails out with `send_expired_notification()` as soon as `remain_timestamp < 0`, so an expired‑but‑still‑refreshable token is never renewed. The refresh path only runs inside the 7‑day pre‑expiry window, and nothing forces it from the expiry event.

Net effect: as soon as the access token crosses its expiry (or the server returns `805`), the user gets nagged with no automatic recovery.

> **Version note for maintainers:** the published **v1.0.2 release** ships a *newer* `oauth.py` than what is in `main` (which still reads `version: 1.0.1` — see #81's "v1.0.1 displayed / v1.0.2 downloaded"). That released file already attempts a forced refresh, but with a bug — the call site uses a keyword that doesn't match the method signature:
> ```python
> # on_token_expired_event
> await self.async_check_token_expiry(force=True)        # but the param is `force_or_now`
> # async def async_check_token_expiry(self, force_or_now=False):
> ```
> which raises, on every token‑expired event, against a live instance:
> ```
> TypeError: AuthTokenRefresh.async_check_token_expiry() got an unexpected keyword argument 'force'
> ```
> So the forced refresh in v1.0.2 never runs either. That improved code was apparently never committed to the repo, so this PR brings the corrected version into `main`.

## What this PR changes

Only `custom_components/bluetti/oauth.py`, two methods:

1. **`on_token_expired_event`** now triggers a forced refresh instead of only notifying:
   ```python
   await self.async_check_token_expiry(force_or_now=True)
   ```
2. **`async_check_token_expiry(self, force_or_now=False)`** gains a `force` path that:
   - redeems the `refresh_token` **even after the access token has expired** (instead of giving up immediately),
   - tolerates tokens that expose `expires_in` + `created_at` instead of `expires_at`,
   - skips the 1‑hour refresh throttle when forced,
   - and only raises the "OAuth Expired" notice when the refresh **genuinely fails** — so transient `805`s self‑heal silently.

The `force` flag is derived as `force_or_now if isinstance(force_or_now, bool) else False`, so the existing `async_track_time_interval` caller (which passes a `datetime`) keeps working unchanged.

## How it fixes the issue

When the cloud reports the token expired, the integration now uses the still‑valid `refresh_token` to obtain a fresh access token and reloads the entry, instead of immediately showing "OAuth Expired". The notification is only shown when the refresh token itself is no longer accepted (i.e. a real re‑login is required), which removes the false‑positive / looping notifications in #75, #81 and #97.

## Scope / limitations (not fixed here)

- **Region endpoints (#72):** EU/German accounts that fail because of the wrong `gateway`/`sso` host in `application.yaml` are a *separate* problem. If the cloud returns `805` because the token belongs to a different region than the configured gateway, refreshing won't help — that still needs the region fix discussed in #72/#75. This PR does not touch `application.yaml`.
- **Initial‑auth failures (#80):** `invalid_grant` / "Received invalid token data" during the *first* OAuth code exchange is a different code path and is not addressed here.
- If a user's `refresh_token` has already fully expired, a one‑time `Reconfigure` is still required; after that, this change keeps the token alive automatically.

## Testing

- Patched file passes `python -m py_compile`.
- Logic validated against a real instance: the original failure mode reproduced the `TypeError` traceback above on every `EVENT_TOKEN_EXPIRED`, and the corrected `force_or_now=True` call resolves to the refresh path. I don't see an automated test suite in the repo, so this was verified by code inspection + live‑log analysis rather than CI.

## Linked issues

Fixes #75
Fixes #81
Fixes #97

Related to #72 (region endpoints) and #80 (initial‑auth `invalid_grant`) — separate problems, see *Scope / limitations* above.