### PR TITLE
Add Apex and Hub A1 cloud support

### DIFF
--- a/custom_components/bluetti/__init__.py
+++ b/custom_components/bluetti/__init__.py
@@ -2,23 +2,31 @@
 # from __future__ import annotations
 
 import logging
-import asyncio
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_oauth2_flow, device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers import storage
-from homeassistant.const import EVENT_HOMEASSISTANT_START
 
 from .models import BluettiData
 from .oauth import AsyncConfigEntryAuth,AuthTokenRefresh
 from .api.bluetti import APPLICATION_PROFILE
 from .api.product_client import ProductClient
 from .api.websocket import StompClient
+from .hub_a1 import (
+    HubA1LookupError,
+    apply_app_device_state_overrides,
+    is_invalid_hub_a1_product,
+    parse_hub_a1_serials,
+    summarize_serial_identity,
+    summarize_state_values,
+)
 from .profile.application_profile import ApplicationProfile
-from .const import DOMAIN
+from .const import CONF_HUB_A1_SERIALS, DOMAIN
 from .model.product import UserProduct
 
 __LOGGER__ = logging.getLogger(__name__)
@@ -32,6 +40,48 @@ type BluettiConfigEntry = ConfigEntry[BluettiData]
 
 
 # type Oauth2ConfigEntry = ConfigEntry[api.AsyncConfigEntryAuth]
+
+
+def _serialize_products(products):
+    serialized = []
+    for product in products:
+        if hasattr(product, "model_dump"):
+            serialized.append(product.model_dump())
+        elif hasattr(product, "__dict__"):
+            serialized.append(product.__dict__)
+        else:
+            serialized.append(product)
+    return serialized
+
+
+async def _refresh_selected_products(product_client: ProductClient, products: list[UserProduct]) -> list[UserProduct]:
+    refreshed_products: list[UserProduct] = []
+    for product in products:
+        try:
+            if product.model == "HA1":
+                refreshed_products.append(await product_client.get_hub_a1_product(product.sn))
+                continue
+
+            app_states = await product_client.get_app_device_state_overrides(product.sn)
+            if app_states:
+                product_data = apply_app_device_state_overrides(product.model_dump(), app_states)
+                refreshed_products.append(UserProduct.model_validate(product_data))
+                continue
+        except HubA1LookupError as exc:
+            __LOGGER__.warning("Unable to refresh selected Hub A1 device before setup: %s", exc)
+        except Exception as exc:
+            __LOGGER__.warning(
+                "Unable to refresh selected BLUETTI device before setup: %s",
+                exc.__class__.__name__,
+            )
+
+        refreshed_products.append(product)
+    return refreshed_products
+
+
+def _replace_products_by_sn(products: list[UserProduct], replacements: list[UserProduct]) -> list[UserProduct]:
+    replacements_by_sn = {product.sn: product for product in replacements}
+    return [replacements_by_sn.get(product.sn, product) for product in products]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> bool:
@@ -73,12 +123,84 @@ async def async_setup_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> b
     # print(products.data[0].__class__)
     # print(products.data)
 
-    selected_products = [p for p in all_products if p.sn in enabled_devices]
+    hub_a1_serials = parse_hub_a1_serials(entry.options.get(CONF_HUB_A1_SERIALS))
+    invalid_hub_a1_sns = {
+        product.sn
+        for product in all_products
+        if is_invalid_hub_a1_product(product)
+    }
+    if invalid_hub_a1_sns:
+        __LOGGER__.warning(
+            "Ignoring invalid cached Hub A1 entries: count=%s targets=%s",
+            len(invalid_hub_a1_sns),
+            ",".join(summarize_serial_identity(serial) for serial in sorted(invalid_hub_a1_sns)),
+        )
+        all_products = [
+            product
+            for product in all_products
+            if product.sn not in invalid_hub_a1_sns
+        ]
+        enabled_devices = [
+            serial
+            for serial in enabled_devices
+            if serial not in invalid_hub_a1_sns
+        ]
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, "products": _serialize_products(all_products)},
+            options={**entry.options, "devices": enabled_devices, CONF_HUB_A1_SERIALS: hub_a1_serials},
+        )
+
+    product_sns = {p.sn for p in all_products}
+    products_changed = False
+    for serial in hub_a1_serials:
+        if serial in product_sns:
+            continue
+        try:
+            product = await product_client.get_hub_a1_product(serial)
+        except HubA1LookupError as exc:
+            __LOGGER__.warning("Unable to load Hub A1 device through app API: %s", exc)
+            continue
+        except Exception as exc:
+            __LOGGER__.warning("Unable to load Hub A1 device through app API: %s", exc.__class__.__name__)
+            continue
+        all_products.append(product)
+        product_sns.add(product.sn)
+        products_changed = True
+
+    if products_changed:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, "products": _serialize_products(all_products)},
+        )
+
+    selected_products = await _refresh_selected_products(
+        product_client,
+        [p for p in all_products if p.sn in enabled_devices],
+    )
+    all_products = _replace_products_by_sn(all_products, selected_products)
+    if selected_products:
+        hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, "products": _serialize_products(all_products)},
+        )
+    if __LOGGER__.isEnabledFor(logging.DEBUG):
+        for product in selected_products:
+            __LOGGER__.debug(
+                "BLUETTI setup product summary before entity setup: model=%s %s",
+                product.model,
+                summarize_state_values(product.stateList or []),
+            )
 
     bluetti_devices = BluettiData(hass, selected_products)
 
     # Register WebSocket
-    stomp_client = StompClient(APPLICATION_PROFILE.config["server"]["wss"], access_token, bluetti_devices.web_socket_message_handler,hass)
+    stomp_client = StompClient(
+        APPLICATION_PROFILE.config["server"]["wss"],
+        access_token,
+        bluetti_devices.web_socket_message_handler,
+        hass,
+    )
     stomp_client.connect()
 
     for device in bluetti_devices.devices:
@@ -90,15 +212,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> b
 
         # device._ws_manager = stomp_client
 
+    async def _async_periodic_refresh(now):
+        for device in bluetti_devices.devices:
+            try:
+                await device.async_update()
+            except Exception as exc:
+                __LOGGER__.warning(
+                    "BLUETTI periodic device refresh failed: model=%s error=%s",
+                    device.model,
+                    exc.__class__.__name__,
+                )
+                continue
+            if __LOGGER__.isEnabledFor(logging.DEBUG):
+                __LOGGER__.debug(
+                    "BLUETTI periodic runtime state summary: model=%s %s",
+                    device.model,
+                    summarize_state_values(device.states),
+                )
+
+    refresh_unsub = async_track_time_interval(
+        hass,
+        _async_periodic_refresh,
+        timedelta(seconds=60),
+    )
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         "bluettiDevices": bluetti_devices,
         "stompClient": stomp_client,
+        "refresh_unsub": refresh_unsub,
     }
 
-    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
-
     for device in bluetti_devices.devices:
-        asyncio.run_coroutine_threadsafe(device.async_update(), hass.loop)
+        try:
+            await device.async_update()
+        except Exception as exc:
+            __LOGGER__.warning(
+                "BLUETTI setup initial device refresh failed before entity setup: model=%s error=%s",
+                device.model,
+                exc.__class__.__name__,
+            )
+        if __LOGGER__.isEnabledFor(logging.DEBUG):
+            __LOGGER__.debug(
+                "BLUETTI setup runtime state summary before entity setup: model=%s %s",
+                device.model,
+                summarize_state_values(device.states),
+            )
+
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     # async def _after_start(event):
     #     # print(event)
@@ -118,17 +278,26 @@ def web_socket_message_handler(message: str):
 # TODO Update entry annotation
 async def async_unload_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> bool:
     """Unload a config entry."""
+    data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if data:
+        refresh_unsub = data.get("refresh_unsub")
+        if refresh_unsub:
+            refresh_unsub()
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
 
 async def async_remove_entry(hass, entry):
     """Handle removal of an entry."""
     data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
-    if data and "stompClient" in data:
-        stomp_client = data["stompClient"]
-        try:
-            stomp_client.disconnect()
-        except Exception as e:
-            __LOGGER__.warning("Error while disconnecting websocket: %s", e)
+    if data:
+        refresh_unsub = data.get("refresh_unsub")
+        if refresh_unsub:
+            refresh_unsub()
+        if "stompClient" in data:
+            stomp_client = data["stompClient"]
+            try:
+                stomp_client.disconnect()
+            except Exception as e:
+                __LOGGER__.warning("Error while disconnecting websocket: %s", e)
 
     device_registry = dr.async_get(hass)
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):

--- a/custom_components/bluetti/api/product_client.py
+++ b/custom_components/bluetti/api/product_client.py
@@ -5,7 +5,29 @@ import aiohttp
 from .bluetti import Bluetti
 from .unify_response import UnifyResponse
 from ..const import Method
+from ..hub_a1 import (
+    HubA1LookupError,
+    build_app_device_state_overrides,
+    build_hub_a1_product_data,
+    build_related_hub_a1_fallback_product_data,
+    describe_hub_a1_lookup_response,
+    has_meaningful_state_values,
+    has_hub_a1_telemetry,
+    select_hub_a1_related_app_device,
+    select_preferred_app_device_payload,
+    summarize_app_home_device_serials,
+    summarize_hub_a1_field_sources,
+    summarize_payload_values,
+    summarize_serial_identity,
+    summarize_state_values,
+)
 from ..model.product import UserProduct
+
+
+def _last_alive_payload(payload: dict) -> dict:
+    """Return a payload's lastAlive mapping when present."""
+    last_alive = payload.get("lastAlive") if isinstance(payload, dict) else None
+    return last_alive if isinstance(last_alive, dict) else {}
 
 
 class ProductClient(Bluetti):
@@ -48,6 +70,314 @@ class ProductClient(Bluetti):
             "/api/bluiotdata/ha/v1/deviceStates",
             params={'sns': sns}
         )
+
+    async def get_app_device_by_sn(self, device_sn: str) -> UnifyResponse[dict]:
+        """Look up a BLUETTI app-side device by serial number."""
+        return await self._request(
+            dict,
+            Method.GET,
+            "/api/blusmartprod/device/basic/v1/deviceRemoteSearch",
+            params={"deviceSn": device_sn},
+        )
+
+    async def get_app_home_devices(self) -> UnifyResponse[list[dict]]:
+        """Get app-side home device records."""
+        return await self._request(
+            list[dict],
+            Method.GET,
+            "/api/blusmartprod/device/group/v1/homeDevices",
+        )
+
+    async def get_app_device_state_overrides(self, device_sn: str) -> list[dict]:
+        """Get app-side state updates for devices omitted or stale in HA APIs."""
+        app_device = await self._get_app_device_payload(device_sn)
+        app_states = build_app_device_state_overrides(app_device)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug(
+                "BLUETTI app state override summary: target=%s states=%s",
+                summarize_serial_identity(device_sn),
+                summarize_state_values(app_states),
+            )
+        return app_states
+
+    async def _get_app_device_payload(self, device_sn: str) -> dict:
+        direct_device = {}
+        serial_summary = summarize_serial_identity(device_sn)
+        debug_logging = self.logger.isEnabledFor(logging.DEBUG)
+        try:
+            response = await self.get_app_device_by_sn(device_sn)
+        except Exception as exc:
+            if debug_logging:
+                self.logger.debug(
+                    "BLUETTI app direct lookup summary: target=%s error=%s",
+                    serial_summary,
+                    exc.__class__.__name__,
+                )
+        else:
+            if response.has_data() and isinstance(response.data, dict) and response.data:
+                direct_device = response.data
+                if debug_logging:
+                    self.logger.debug(
+                        "BLUETTI app direct lookup summary: target=%s status=%s data=%s lastAlive=%s",
+                        serial_summary,
+                        describe_hub_a1_lookup_response(response),
+                        summarize_payload_values(response.data),
+                        summarize_payload_values(_last_alive_payload(response.data)),
+                    )
+            else:
+                if debug_logging:
+                    self.logger.debug(
+                        "BLUETTI app direct lookup summary: target=%s status=%s data=%s",
+                        serial_summary,
+                        describe_hub_a1_lookup_response(response),
+                        summarize_payload_values(response.data),
+                    )
+
+        home_devices = await self._get_app_home_devices_payload()
+        selected = select_preferred_app_device_payload(
+            device_sn,
+            direct_device,
+            home_devices,
+            max_age_seconds=900,
+        )
+        if selected and selected is not direct_device:
+            if debug_logging:
+                    self.logger.debug(
+                        "BLUETTI app selected home-device payload: data=%s lastAlive=%s",
+                        summarize_payload_values(selected),
+                        summarize_payload_values(_last_alive_payload(selected)),
+                    )
+        return selected
+
+    async def _get_app_home_devices_payload(self) -> list[dict]:
+        debug_logging = self.logger.isEnabledFor(logging.DEBUG)
+        try:
+            response = await self.get_app_home_devices()
+        except Exception as exc:
+            if debug_logging:
+                self.logger.debug("BLUETTI app home devices summary: error=%s", exc.__class__.__name__)
+            return []
+
+        if not response.is_ok() or not isinstance(response.data, list):
+            if debug_logging:
+                self.logger.debug(
+                    "BLUETTI app home devices summary: status=%s data=%s",
+                    describe_hub_a1_lookup_response(response),
+                    summarize_payload_values(response.data),
+                )
+            return []
+
+        if debug_logging:
+            self.logger.debug(
+                "BLUETTI app home devices summary: status=%s data=%s",
+                describe_hub_a1_lookup_response(response),
+                summarize_payload_values(response.data),
+            )
+        return response.data
+
+    async def get_aecc_realtime_data(self, device_sn: str) -> UnifyResponse[dict]:
+        """Get Hub A1 realtime AECC telemetry."""
+        return await self._request(
+            dict,
+            Method.POST,
+            "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_device_last_alive(self, device_sn: str) -> UnifyResponse[dict]:
+        """Get Hub A1 last-alive realtime telemetry."""
+        return await self._request(
+            dict,
+            Method.POST,
+            "/api/bluiotdata/realtime/v1/getDeviceLastAlive",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_aecc_battery_detail_data(self, device_sn: str) -> UnifyResponse[list[dict]]:
+        """Get Hub A1 battery detail telemetry."""
+        return await self._request(
+            list[dict],
+            Method.POST,
+            "/api/bluiotdata/aecc/v1/getDeviceBatteryDetailData",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_aecc_pv_detail_data(self, device_sn: str) -> UnifyResponse[list[dict]]:
+        """Get Hub A1 PV detail telemetry."""
+        return await self._request(
+            list[dict],
+            Method.POST,
+            "/api/bluiotdata/aecc/v1/getDevicePvDetailData",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_aecc_load_detail_data(self, device_sn: str) -> UnifyResponse[list[dict]]:
+        """Get Hub A1 load detail telemetry."""
+        return await self._request(
+            list[dict],
+            Method.POST,
+            "/api/bluiotdata/aecc/v1/getDeviceLoadDetailData",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_aecc_grid_detail_data(self, device_sn: str) -> UnifyResponse[list[dict]]:
+        """Get Hub A1 grid detail telemetry."""
+        return await self._request(
+            list[dict],
+            Method.POST,
+            "/api/bluiotdata/aecc/v1/getDeviceGridDetailData",
+            body={"deviceSn": device_sn},
+        )
+
+    async def get_hub_a1_product(self, device_sn: str) -> UserProduct:
+        """Build a UserProduct-shaped Hub A1 object from read-only app APIs."""
+        app_device = {}
+        app_lookup_status = "not requested"
+        serial_summary = summarize_serial_identity(device_sn)
+        debug_logging = self.logger.isEnabledFor(logging.DEBUG)
+
+        try:
+            app_device_response = await self.get_app_device_by_sn(device_sn)
+        except Exception as exc:
+            app_lookup_status = exc.__class__.__name__
+        else:
+            app_lookup_status = describe_hub_a1_lookup_response(app_device_response)
+            if (
+                app_device_response.has_data()
+                and isinstance(app_device_response.data, dict)
+                and app_device_response.data
+            ):
+                app_device = app_device_response.data
+
+        if debug_logging:
+            self.logger.debug(
+                "Hub A1 app lookup summary: target=%s status=%s data=%s lastAlive=%s",
+                serial_summary,
+                app_lookup_status,
+                summarize_payload_values(app_device),
+                summarize_payload_values(_last_alive_payload(app_device)),
+            )
+
+        realtime = await self._optional_response_data(
+            "realtime", self.get_aecc_realtime_data, device_sn, {}
+        )
+        last_alive = await self._optional_response_data(
+            "lastAlive", self.get_device_last_alive, device_sn, {}
+        )
+        battery_details = await self._optional_response_data(
+            "batteryDetails", self.get_aecc_battery_detail_data, device_sn, []
+        )
+        pv_details = await self._optional_response_data(
+            "pvDetails", self.get_aecc_pv_detail_data, device_sn, []
+        )
+        load_details = await self._optional_response_data(
+            "loadDetails", self.get_aecc_load_detail_data, device_sn, []
+        )
+        grid_details = await self._optional_response_data(
+            "gridDetails", self.get_aecc_grid_detail_data, device_sn, []
+        )
+        if debug_logging:
+            self.logger.debug(
+                "Hub A1 selected field source summary: target=%s %s",
+                serial_summary,
+                summarize_hub_a1_field_sources(
+                    app_device=app_device,
+                    realtime=realtime,
+                    last_alive=last_alive,
+                    battery_details=battery_details,
+                ),
+            )
+
+        if not app_device and not has_hub_a1_telemetry(
+            realtime=realtime,
+            last_alive=last_alive,
+            battery_details=battery_details,
+            pv_details=pv_details,
+            load_details=load_details,
+            grid_details=grid_details,
+        ):
+            raise HubA1LookupError(
+                f"Hub A1 lookup returned no app device and no telemetry fallback ({app_lookup_status})"
+            )
+
+        product_data = build_hub_a1_product_data(
+            device_sn,
+            app_device=app_device,
+            realtime=realtime,
+            last_alive=last_alive,
+            battery_details=battery_details,
+            pv_details=pv_details,
+            load_details=load_details,
+            grid_details=grid_details,
+        )
+        if not has_meaningful_state_values(product_data["stateList"]):
+            home_devices = await self._get_app_home_devices_payload()
+            if debug_logging:
+                self.logger.debug(
+                    "Hub A1 app home serial summary: %s",
+                    summarize_app_home_device_serials(device_sn, home_devices),
+                )
+            related_app_device = select_hub_a1_related_app_device(
+                home_devices,
+                max_age_seconds=900,
+            )
+            related_last_alive = (
+                related_app_device.get("lastAlive")
+                if isinstance(related_app_device.get("lastAlive"), dict)
+                else {}
+            )
+            if related_app_device and related_last_alive:
+                if debug_logging:
+                    self.logger.debug(
+                        "Hub A1 related app telemetry fallback summary: data=%s lastAlive=%s",
+                        summarize_payload_values(related_app_device),
+                        summarize_payload_values(related_last_alive),
+                    )
+                product_data = build_related_hub_a1_fallback_product_data(
+                    device_sn,
+                    related_app_device,
+                )
+        if debug_logging:
+            self.logger.debug(
+                "Hub A1 built state summary: %s",
+                summarize_state_values(product_data["stateList"]),
+            )
+        return UserProduct.model_validate(product_data)
+
+    async def _optional_response_data(self, label: str, request, device_sn: str, default):
+        serial_summary = summarize_serial_identity(device_sn)
+        debug_logging = self.logger.isEnabledFor(logging.DEBUG)
+        try:
+            response = await request(device_sn)
+        except Exception as exc:
+            if debug_logging:
+                self.logger.debug(
+                    "Hub A1 optional telemetry summary: endpoint=%s target=%s error=%s",
+                    label,
+                    serial_summary,
+                    exc.__class__.__name__,
+                )
+            return default
+        if not response.is_ok():
+            if debug_logging:
+                self.logger.debug(
+                    "Hub A1 optional telemetry summary: endpoint=%s target=%s status=%s data=%s",
+                    label,
+                    serial_summary,
+                    describe_hub_a1_lookup_response(response),
+                    summarize_payload_values(response.data),
+                )
+            return default
+        data = response.data if response.data is not None else default
+        if debug_logging:
+            self.logger.debug(
+                "Hub A1 optional telemetry summary: endpoint=%s target=%s status=%s data=%s",
+                label,
+                serial_summary,
+                describe_hub_a1_lookup_response(response),
+                summarize_payload_values(data),
+            )
+        return data
 
     async def control_device(self, payload: str = None):
         """

--- a/custom_components/bluetti/api/unify_response.py
+++ b/custom_components/bluetti/api/unify_response.py
@@ -9,6 +9,9 @@ class UnifyResponse(BaseModel, Generic[T]):
 
     msgId: str
     msgCode: int
+    code: int | None = None
+    message: str | None = None
+    error: str | None = None
     data: T | None = None
 
     # def __init__(self, msgId: str, msgCode: int):

--- a/custom_components/bluetti/const.py
+++ b/custom_components/bluetti/const.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 DOMAIN: str = "bluetti"
 INTEGRATION_NAME: str = 'BLUETTI'
+CONF_HUB_A1_SERIALS: str = "hub_a1_serials"
 
 EVENT_TOKEN_EXPIRED: str ="onTokenExpired"
 NOTIFY_ID_TOKEN_EXPIRED: str ="notifyTokenExpire"

--- a/custom_components/bluetti/hub_a1.py
+++ b/custom_components/bluetti/hub_a1.py
@@ -1,0 +1,960 @@
+"""Hub A1 helpers for BLUETTI app API payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime
+from typing import Any
+
+
+HUB_A1_MODEL = "HA1"
+
+SENSOR_TYPE_BATTERY = "SensorDeviceClass.BATTERY"
+SENSOR_TYPE_ENERGY = "SensorDeviceClass.ENERGY"
+SENSOR_TYPE_POWER = "SensorDeviceClass.POWER"
+SENSOR_TYPE_VOLTAGE = "SensorDeviceClass.VOLTAGE"
+
+TELEMETRY_KEYS = {
+    "acswitch",
+    "batsoc",
+    "batterysoc",
+    "batterysoh",
+    "batteryvoltage",
+    "battoloadpower",
+    "chgfulltime",
+    "currentforbms",
+    "dcswitch",
+    "dctotalenergy",
+    "dsgemptytime",
+    "frequency",
+    "gridbatpower",
+    "gridswitch",
+    "gridtoloadpower",
+    "metertotalenergy",
+    "packaveragetemp",
+    "packtotalchgenergy",
+    "packtotaldsgenergy",
+    "power",
+    "poweracout",
+    "powerbatterycharge",
+    "powerdcout",
+    "powerfeedback",
+    "powergridin",
+    "powerinvtotal",
+    "powerloadout",
+    "powerpvin",
+    "pvswitch",
+    "pvtobatpower",
+    "pvtogridpower",
+    "pvtotalenergy",
+    "voltage",
+}
+
+RELATED_HUB_A1_FALLBACK_KEYS = {
+    "acSwitch",
+    "dcSwitch",
+    "dcTotalEnergy",
+    "gridSwitch",
+    "powerLoadOut",
+    "powerAcOut",
+    "powerDcOut",
+    "powerGridIn",
+    "powerPvIn",
+    "timestamp",
+}
+
+RELATED_HUB_A1_SYSTEM_FALLBACK_KEYS = {
+    "batterySoc",
+    "batterySoh",
+    "batteryVoltage",
+    "meterTotalEnergy",
+    "powerBatteryCharge",
+}
+
+
+class HubA1LookupError(RuntimeError):
+    """Raised when a Hub A1 cannot be resolved from app or telemetry APIs."""
+
+
+def parse_hub_a1_serials(value: Any) -> list[str]:
+    """Parse a comma/whitespace separated Hub A1 serial field."""
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        parts = [str(item).strip() for item in value]
+    else:
+        parts = [part.strip() for part in re.split(r"[\r\n,;]+", str(value))]
+
+    serials: list[str] = []
+    for part in parts:
+        if is_hub_a1_serial_candidate(part) and part not in serials:
+            serials.append(part)
+    return serials
+
+
+def is_hub_a1_serial_candidate(value: Any) -> bool:
+    """Return true for values that look like serials rather than names/models."""
+    if value is None:
+        return False
+    value_text = str(value).strip()
+    if len(value_text) < 8 or len(value_text) > 64:
+        return False
+    if any(char.isspace() for char in value_text):
+        return False
+    serial_text = value_text.replace("-", "").replace("_", "")
+    return serial_text.isalnum() and any(char.isalpha() for char in serial_text) and any(
+        char.isdigit() for char in serial_text
+    )
+
+
+def is_invalid_hub_a1_product(product: Any) -> bool:
+    """Return true for cached HA1 products whose sn is not a serial."""
+    if isinstance(product, dict):
+        model = product.get("model")
+        serial = product.get("sn")
+    else:
+        model = getattr(product, "model", None)
+        serial = getattr(product, "sn", None)
+    return str(model or "").upper() == HUB_A1_MODEL and not is_hub_a1_serial_candidate(serial)
+
+
+def build_hub_a1_product_data(
+    serial: str,
+    *,
+    app_device: dict[str, Any] | None = None,
+    realtime: dict[str, Any] | None = None,
+    last_alive: dict[str, Any] | None = None,
+    battery_details: list[dict[str, Any]] | None = None,
+    pv_details: list[dict[str, Any]] | None = None,
+    load_details: list[dict[str, Any]] | None = None,
+    grid_details: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a synthetic UserProduct-shaped dict from Hub A1 app telemetry."""
+    app_device = app_device or {}
+    realtime = realtime or {}
+    last_alive = last_alive or {}
+
+    return {
+        "sn": serial,
+        "stateList": build_hub_a1_state_list(
+            app_device=app_device,
+            realtime=realtime,
+            last_alive=last_alive,
+            battery_details=battery_details,
+            pv_details=pv_details,
+            load_details=load_details,
+            grid_details=grid_details,
+        ),
+        "online": _online_value(app_device, last_alive),
+        "model": app_device.get("model") or HUB_A1_MODEL,
+        "name": app_device.get("name") or serial,
+        "isBindByCurUser": "1",
+    }
+
+
+def has_hub_a1_telemetry(
+    *,
+    realtime: dict[str, Any] | None,
+    last_alive: dict[str, Any] | None,
+    battery_details: list[dict[str, Any]] | None,
+    pv_details: list[dict[str, Any]] | None,
+    load_details: list[dict[str, Any]] | None,
+    grid_details: list[dict[str, Any]] | None,
+) -> bool:
+    """Return true when any Hub A1 telemetry endpoint returned usable data."""
+    return any(
+        _telemetry_payload_score(value) > 0
+        for value in (
+            realtime,
+            last_alive,
+            battery_details,
+            pv_details,
+            load_details,
+            grid_details,
+        )
+    )
+
+
+def describe_hub_a1_lookup_response(response: Any) -> str:
+    """Return a safe, identifier-redacted description of a BLUETTI response."""
+    parts = []
+    for key in ("msgCode", "code", "message"):
+        if hasattr(response, key):
+            value = _redact_identifier_text(str(getattr(response, key)))
+            parts.append(f"{key}={value}")
+    data = getattr(response, "data", None)
+    if isinstance(data, dict):
+        parts.append(f"data_keys={len(data)}")
+    elif isinstance(data, list):
+        parts.append(f"data_len={len(data)}")
+    elif data is None:
+        parts.append("data=None")
+    else:
+        parts.append(f"data_type={type(data).__name__}")
+    return ", ".join(parts) if parts else type(response).__name__
+
+
+def summarize_state_values(states: list[Any], *, limit: int = 6) -> str:
+    """Return a serial-safe summary of state values for diagnostics."""
+    total = 0
+    zero = 0
+    nonzero = 0
+    empty = 0
+    samples: list[str] = []
+
+    for state in states:
+        if isinstance(state, dict):
+            fn_code = state.get("fnCode")
+            value = state.get("fnValue")
+        else:
+            fn_code = getattr(state, "fn_code", None)
+            value = getattr(state, "fn_value", None)
+
+        if not fn_code:
+            continue
+
+        total += 1
+        value_text = "" if value is None else str(value)
+        if value_text == "":
+            empty += 1
+            continue
+        if _is_zero_value(value_text):
+            zero += 1
+            continue
+
+        nonzero += 1
+        if len(samples) < limit:
+            safe_code = _redact_identifier_text(str(fn_code))
+            safe_value = _redact_identifier_text(value_text)
+            samples.append(f"{safe_code}={safe_value}")
+
+    sample_text = ",".join(samples) if samples else "none"
+    return f"states={total} nonzero={nonzero} zero={zero} empty={empty} samples={sample_text}"
+
+
+def has_meaningful_state_values(states: list[Any]) -> bool:
+    """Return true when states contain nonzero values other than online."""
+    for state in states:
+        if isinstance(state, dict):
+            fn_code = state.get("fnCode")
+            value = state.get("fnValue")
+        else:
+            fn_code = getattr(state, "fn_code", None)
+            value = getattr(state, "fn_value", None)
+        if not fn_code or str(fn_code) == "onLine":
+            continue
+        value_text = "" if value is None else str(value)
+        if value_text != "" and not _is_zero_value(value_text):
+            return True
+    return False
+
+
+def summarize_payload_values(payload: Any, *, limit: int = 6) -> str:
+    """Return a serial-safe summary of API payload scalar values."""
+    row_count = len(payload) if isinstance(payload, list) else None
+    field_count = 0
+    zero = 0
+    nonzero = 0
+    empty = 0
+    samples: list[str] = []
+
+    for key, value in _iter_payload_scalars(payload):
+        field_count += 1
+        value_text = "" if value is None else str(value)
+        if value_text == "":
+            empty += 1
+            continue
+        if _is_zero_value(value_text):
+            zero += 1
+            continue
+
+        nonzero += 1
+        if len(samples) < limit and not _is_identifier_key(key):
+            safe_key = _redact_identifier_text(key)
+            safe_value = _redact_identifier_text(value_text)
+            samples.append(f"{safe_key}={safe_value}")
+
+    parts = []
+    if row_count is not None:
+        parts.append(f"rows={row_count}")
+    parts.extend(
+        [
+            f"fields={field_count}",
+            f"nonzero={nonzero}",
+            f"zero={zero}",
+            f"empty={empty}",
+            f"samples={','.join(samples) if samples else 'none'}",
+        ]
+    )
+    return " ".join(parts)
+
+
+def summarize_hub_a1_field_sources(
+    *,
+    app_device: dict[str, Any] | None = None,
+    realtime: dict[str, Any] | None = None,
+    last_alive: dict[str, Any] | None = None,
+    battery_details: list[dict[str, Any]] | None = None,
+) -> str:
+    """Return a concise summary of the source selected for key HA1 fields."""
+    app_device = app_device or {}
+    realtime = realtime or {}
+    last_alive = last_alive or {}
+    battery_details = battery_details or []
+
+    fields = [
+        (
+            "BatterySoc",
+            [
+                ("lastAlive.batterySoc", last_alive.get("batterySoc")),
+                ("realtime.batterySoc", realtime.get("batterySoc")),
+                ("app.batSOC", app_device.get("batSOC")),
+            ],
+        ),
+        (
+            "BatteryVoltage",
+            [
+                ("lastAlive.batteryVoltage", last_alive.get("batteryVoltage")),
+                ("batteryDetails.voltage", _first_detail_value(battery_details, "voltage")),
+            ],
+        ),
+        (
+            "AcPowerOut",
+            [
+                ("realtime.powerLoadOut", realtime.get("powerLoadOut")),
+                ("lastAlive.powerLoadOut", last_alive.get("powerLoadOut")),
+                ("lastAlive.powerAcOut", last_alive.get("powerAcOut")),
+                ("app.powerAcOut", app_device.get("powerAcOut")),
+            ],
+        ),
+        (
+            "GridPowerIn",
+            [
+                ("realtime.powerGridIn", realtime.get("powerGridIn")),
+                ("lastAlive.powerGridIn", last_alive.get("powerGridIn")),
+                ("lastAlive.powerFeedBack", last_alive.get("powerFeedBack")),
+                ("app.powerGridIn", app_device.get("powerGridIn")),
+            ],
+        ),
+        (
+            "InverterTotalPower",
+            [
+                ("lastAlive.powerInvTotal", last_alive.get("powerInvTotal")),
+            ],
+        ),
+        (
+            "PvPowerIn",
+            [
+                ("realtime.powerPvIn", realtime.get("powerPvIn")),
+                ("lastAlive.powerPvIn", last_alive.get("powerPvIn")),
+                ("app.powerPvIn", app_device.get("powerPvIn")),
+            ],
+        ),
+        (
+            "DcPowerOut",
+            [
+                ("lastAlive.powerDcOut", last_alive.get("powerDcOut")),
+                ("app.powerDcOut", app_device.get("powerDcOut")),
+            ],
+        ),
+        (
+            "BatteryChargePower",
+            [
+                ("realtime.powerBatteryCharge", realtime.get("powerBatteryCharge")),
+                ("lastAlive.powerBatteryCharge", last_alive.get("powerBatteryCharge")),
+            ],
+        ),
+        (
+            "MeterTotalEnergy",
+            [
+                ("realtime.meterTotalEnergy", realtime.get("meterTotalEnergy")),
+                ("lastAlive.meterTotalEnergy", last_alive.get("meterTotalEnergy")),
+            ],
+        ),
+    ]
+
+    summaries = [_selected_source_summary(name, sources) for name, sources in fields]
+    summaries.append(
+        _selected_source_summary(
+            "BatteryTotalChargeEnergy",
+            [("lastAlive.packTotalChgEnergy", last_alive.get("packTotalChgEnergy"))],
+        )
+    )
+    summaries.append(
+        _ignored_source_summary(
+            "PackTotalDischargeEnergy",
+            "lastAlive.packTotalDsgEnergy",
+            last_alive.get("packTotalDsgEnergy"),
+            "ignored_displayed_as_charge",
+        )
+    )
+    return ",".join(summaries)
+
+
+def _selected_source_summary(field_name: str, sources: list[tuple[str, Any]]) -> str:
+    first_present: tuple[str, Any] | None = None
+    for label, value in sources:
+        if value is None or value == "":
+            continue
+        if first_present is None:
+            first_present = (label, value)
+        if not _is_zero_value(value):
+            safe_value = _redact_identifier_text(str(value))
+            return f"{field_name}={label}:{safe_value}"
+    if first_present is None:
+        return f"{field_name}=none"
+    label, value = first_present
+    safe_value = _redact_identifier_text(str(value))
+    return f"{field_name}=zero:{label}:{safe_value}"
+
+
+def _ignored_source_summary(
+    field_name: str,
+    label: str,
+    value: Any,
+    reason: str,
+) -> str:
+    if value is None or value == "":
+        return f"{field_name}=none"
+    safe_value = _redact_identifier_text(str(value))
+    return f"{field_name}={reason}:{label}:{safe_value}"
+
+
+def summarize_serial_identity(value: Any) -> str:
+    """Return a stable, non-reversible serial summary for log correlation."""
+    if value is None:
+        return "empty"
+    value_text = str(value).strip()
+    if not value_text:
+        return "empty"
+    digest = hashlib.sha256(value_text.encode("utf-8")).hexdigest()[:16]
+    return f"len={len(value_text)} sha256={digest}"
+
+
+def summarize_app_home_device_serials(
+    target_serial: Any,
+    home_devices: list[dict[str, Any]] | None,
+    *,
+    limit: int = 6,
+) -> str:
+    """Summarize app home-device serials without exposing identifiers."""
+    target_text = _normalize_serial_text(target_serial)
+    device_count = 0
+    matches = 0
+    samples: list[str] = []
+
+    for item in home_devices or []:
+        if not isinstance(item, dict):
+            continue
+        device_count += 1
+        item_serial = _payload_serial_value(item)
+        item_serial_text = _normalize_serial_text(item_serial)
+        if target_text and item_serial_text == target_text:
+            matches += 1
+        if len(samples) < limit:
+            model = _redact_identifier_text(str(item.get("model") or "unknown"))
+            identity = summarize_serial_identity(item_serial) if item_serial_text else "missing"
+            samples.append(f"{model}:{identity}")
+
+    return (
+        f"target={summarize_serial_identity(target_serial)} "
+        f"home_devices={device_count} matches={matches} "
+        f"samples={','.join(samples) if samples else 'none'}"
+    )
+
+
+def app_device_telemetry_score(app_device: dict[str, Any] | None) -> int:
+    """Return a rough score for useful app-side telemetry in a device payload."""
+    if not isinstance(app_device, dict) or not app_device:
+        return 0
+
+    top_level = {
+        key: value
+        for key, value in app_device.items()
+        if key != "lastAlive"
+    }
+    score = _telemetry_payload_score(top_level)
+    last_alive = app_device.get("lastAlive")
+    if isinstance(last_alive, dict) and not _is_all_field_null(last_alive):
+        score += 3 * _telemetry_payload_score(last_alive)
+    return score
+
+
+def select_preferred_app_device_payload(
+    device_sn: str,
+    direct_device: dict[str, Any] | None,
+    home_devices: list[dict[str, Any]] | None,
+    *,
+    now: datetime | None = None,
+    max_age_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Select the richest app-side payload for a specific device serial."""
+    direct_device = direct_device or {}
+    home_match = {}
+    for item in home_devices or []:
+        if (
+            isinstance(item, dict)
+            and item.get("sn") == device_sn
+            and _is_recent_app_device_telemetry(
+                item,
+                now=now,
+                max_age_seconds=max_age_seconds,
+            )
+        ):
+            home_match = item
+            break
+
+    if not direct_device:
+        return home_match
+    if not home_match:
+        return direct_device
+
+    if app_device_telemetry_score(home_match) > app_device_telemetry_score(direct_device):
+        return home_match
+    return direct_device
+
+
+def select_hub_a1_related_app_device(
+    home_devices: list[dict[str, Any]] | None,
+    *,
+    now: datetime | None = None,
+    max_age_seconds: int | None = None,
+) -> dict[str, Any]:
+    """Select an Apex-family app device whose telemetry can represent a Hub A1."""
+    candidates = []
+    for item in home_devices or []:
+        if not isinstance(item, dict):
+            continue
+        if not _is_recent_app_device_telemetry(
+            item,
+            now=now,
+            max_age_seconds=max_age_seconds,
+        ):
+            continue
+        telemetry_score = app_device_telemetry_score(item)
+        model_score = _hub_related_model_score(item.get("model"))
+        if telemetry_score > 0 and model_score > 0:
+            candidates.append((model_score, telemetry_score, item))
+    if not candidates:
+        return {}
+    return max(candidates, key=lambda candidate: (candidate[0], candidate[1]))[2]
+
+
+def build_related_hub_a1_fallback_product_data(
+    serial: str,
+    related_app_device: dict[str, Any],
+) -> dict[str, Any]:
+    """Build HA1 fallback states from related app telemetry without battery identity."""
+    related_last_alive = related_app_device.get("lastAlive")
+    if not isinstance(related_last_alive, dict):
+        related_last_alive = {}
+    fallback_keys = RELATED_HUB_A1_FALLBACK_KEYS
+    if _is_hub_related_system_model(related_app_device.get("model")):
+        fallback_keys = fallback_keys | RELATED_HUB_A1_SYSTEM_FALLBACK_KEYS
+    fallback_last_alive = {
+        key: value
+        for key, value in related_last_alive.items()
+        if key in fallback_keys
+    }
+    fallback_app_device = {
+        "model": HUB_A1_MODEL,
+        "networkConnect": related_app_device.get("networkConnect"),
+        "sessionState": related_app_device.get("sessionState"),
+        "powerAcOut": related_app_device.get("powerAcOut"),
+        "powerDcOut": related_app_device.get("powerDcOut"),
+        "powerGridIn": related_app_device.get("powerGridIn"),
+        "powerPvIn": related_app_device.get("powerPvIn"),
+    }
+    return build_hub_a1_product_data(
+        serial,
+        app_device=fallback_app_device,
+        last_alive=fallback_last_alive,
+    )
+
+
+def build_hub_a1_state_list(
+    *,
+    app_device: dict[str, Any] | None = None,
+    realtime: dict[str, Any] | None = None,
+    last_alive: dict[str, Any] | None = None,
+    battery_details: list[dict[str, Any]] | None = None,
+    pv_details: list[dict[str, Any]] | None = None,
+    load_details: list[dict[str, Any]] | None = None,
+    grid_details: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Return state descriptors consumable by the existing BLUETTI entities."""
+    app_device = app_device or {}
+    realtime = realtime or {}
+    last_alive = last_alive or {}
+    battery_details = battery_details or []
+    pv_details = pv_details or []
+    load_details = load_details or []
+    grid_details = grid_details or []
+    battery_total_charge_energy = _centi_kwh_value(last_alive.get("packTotalChgEnergy"))
+
+    states = [
+        _binary_sensor("onLine", "Online", _online_value(app_device, last_alive)),
+        _battery_sensor("HubA1BatterySoc", "Battery SOC", _first_nonzero(last_alive.get("batterySoc"), realtime.get("batterySoc"), app_device.get("batSOC"))),
+        _voltage_sensor(
+            "HubA1BatteryVoltage",
+            "Battery Voltage",
+            _first(last_alive.get("batteryVoltage"), _first_detail_value(battery_details, "voltage")),
+        ),
+        _power_sensor("HubA1AcPowerOut", "AC Output Power", _first_nonzero(realtime.get("powerLoadOut"), last_alive.get("powerLoadOut"), last_alive.get("powerAcOut"), app_device.get("powerAcOut"))),
+        _power_sensor("HubA1DcPowerOut", "DC Output Power", _first_nonzero(last_alive.get("powerDcOut"), app_device.get("powerDcOut"))),
+        _power_sensor("HubA1GridPowerIn", "Grid Input Power", _first_nonzero(realtime.get("powerGridIn"), last_alive.get("powerGridIn"), last_alive.get("powerFeedBack"), app_device.get("powerGridIn"))),
+        _power_sensor("HubA1PvPowerIn", "PV Input Power", _first_nonzero(realtime.get("powerPvIn"), last_alive.get("powerPvIn"), app_device.get("powerPvIn"))),
+        _power_sensor("HubA1BatteryChargePower", "Battery Charge Power", _first_nonzero(realtime.get("powerBatteryCharge"), last_alive.get("powerBatteryCharge"))),
+        _energy_sensor("HubA1DcTotalEnergy", "DC Total Energy", last_alive.get("dcTotalEnergy")),
+        _energy_sensor("HubA1PackTotalChargeEnergy", "Battery Total Charge Energy", battery_total_charge_energy),
+        _binary_sensor("HubA1AcSwitch", "AC Switch", last_alive.get("acSwitch")),
+        _binary_sensor("HubA1DcSwitch", "DC Switch", last_alive.get("dcSwitch")),
+        _binary_sensor("HubA1GridSwitch", "Grid Switch", last_alive.get("gridSwitch")),
+    ]
+
+    _append_detail_states(states, "HubA1Battery", "Battery", battery_details, include_status=True)
+    _append_detail_states(states, "HubA1Pv", "PV", pv_details)
+    _append_detail_states(states, "HubA1Load", "Load", load_details)
+    _append_detail_states(states, "HubA1Grid", "Grid", grid_details)
+
+    return [state for state in states if state is not None]
+
+
+def build_app_device_state_overrides(app_device: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Build updates for app-side devices whose HA endpoint returns stale zeros."""
+    app_device = app_device or {}
+    if not app_device:
+        return []
+    last_alive = app_device.get("lastAlive") if isinstance(app_device.get("lastAlive"), dict) else {}
+
+    states = [
+        _binary_sensor("onLine", "Online", _online_value(app_device, last_alive)),
+        _battery_sensor("SOC", "Battery Level", _first(last_alive.get("batterySoc"), app_device.get("batSOC"))),
+        _battery_sensor("BatterySoh", "Battery SOH", last_alive.get("batterySoh")),
+        _voltage_sensor("BatteryVoltage", "Battery Voltage", last_alive.get("batteryVoltage")),
+        _power_sensor("ACLoadAllTotalPower", "Alternating Current Out Power", _first(last_alive.get("powerAcOut"), app_device.get("powerAcOut"))),
+        _power_sensor("DCLoadAllTotalPower", "Direct Current Out Power", _first(last_alive.get("powerDcOut"), app_device.get("powerDcOut"))),
+        _power_sensor("GridAllTotalPower", "Grid Input Power", _first(last_alive.get("powerGridIn"), app_device.get("powerGridIn"))),
+        _power_sensor("PVAllTotalPower", "Photovoltaics Input Power", _first(last_alive.get("powerPvIn"), app_device.get("powerPvIn"))),
+        _duration_sensor("ChgFullTime", "Full Charge Time In Minutes", last_alive.get("chgFullTime")),
+        _duration_sensor("DsgFullTime", "Battery Time In Minutes", last_alive.get("dsgEmptyTime")),
+        _energy_sensor("PackTotalChargeEnergy", "Pack Total Charge Energy", _centi_kwh_value(last_alive.get("packTotalChgEnergy"))),
+        _energy_sensor("PackTotalDischargeEnergy", "Pack Total Discharge Energy", _centi_kwh_value(last_alive.get("packTotalDsgEnergy"))),
+        _energy_sensor("PvTotalEnergy", "PV Total Energy", last_alive.get("pvTotalEnergy")),
+        _switch_state("SetCtrlAc", "AC", last_alive.get("acSwitch")),
+        _switch_state("SetCtrlDc", "DC", last_alive.get("dcSwitch")),
+    ]
+
+    return [state for state in states if state is not None]
+
+
+def apply_app_device_state_overrides(
+    product_data: dict[str, Any],
+    app_states: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Apply app-side state updates to a cached UserProduct-shaped dict."""
+    updated_product = dict(product_data)
+    state_list = [
+        dict(state)
+        for state in (updated_product.get("stateList") or [])
+        if isinstance(state, dict)
+    ]
+    states_by_code = {
+        state.get("fnCode"): state
+        for state in state_list
+        if state.get("fnCode")
+    }
+
+    for app_state in app_states:
+        fn_code = app_state.get("fnCode")
+        if not fn_code:
+            continue
+        if fn_code == "onLine":
+            updated_product["online"] = app_state.get("fnValue")
+            continue
+        existing_state = states_by_code.get(fn_code)
+        if existing_state is None:
+            new_state = dict(app_state)
+            state_list.append(new_state)
+            states_by_code[fn_code] = new_state
+            continue
+
+        existing_state["fnValue"] = app_state.get("fnValue")
+        if not existing_state.get("fnName") and app_state.get("fnName"):
+            existing_state["fnName"] = app_state["fnName"]
+        if not existing_state.get("fnType") and app_state.get("fnType"):
+            existing_state["fnType"] = app_state["fnType"]
+        if not existing_state.get("sensorInfo") and app_state.get("sensorInfo"):
+            existing_state["sensorInfo"] = app_state["sensorInfo"]
+        if not existing_state.get("supportModeValues") and app_state.get("supportModeValues"):
+            existing_state["supportModeValues"] = app_state["supportModeValues"]
+
+    updated_product["stateList"] = state_list
+    return updated_product
+
+
+def _append_detail_states(
+    states: list[dict[str, Any] | None],
+    prefix: str,
+    default_label: str,
+    rows: list[dict[str, Any]],
+    *,
+    include_status: bool = False,
+) -> None:
+    for index, row in enumerate(rows, start=1):
+        if not _has_nonzero_detail_state(row, include_status=include_status):
+            continue
+        label = str(row.get("portName") or f"{default_label} {index}").strip()
+        states.append(_power_sensor(f"{prefix}{index}Power", f"{label} Power", row.get("power")))
+        states.append(_voltage_sensor(f"{prefix}{index}Voltage", f"{label} Voltage", row.get("voltage")))
+        if include_status:
+            states.append(_plain_sensor(f"{prefix}{index}Status", f"{label} Status", row.get("status")))
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _first_nonzero(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "" and not _is_zero_value(value):
+            return value
+    return _first(*values)
+
+
+def _first_detail_value(rows: list[dict[str, Any]], key: str) -> Any:
+    for row in rows:
+        value = row.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _is_zero_value(value: Any) -> bool:
+    value_text = str(value).strip().lower()
+    if value_text in {"false", "off"}:
+        return True
+    try:
+        return float(value_text) == 0
+    except ValueError:
+        return False
+
+
+def _centi_kwh_value(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    try:
+        scaled_value = float(str(value).strip()) / 100
+    except ValueError:
+        return None
+    return f"{scaled_value:.2f}"
+
+
+def _has_nonzero_detail_state(row: dict[str, Any], *, include_status: bool) -> bool:
+    keys = ["power", "voltage"]
+    if include_status:
+        keys.append("status")
+    return any(
+        row.get(key) is not None
+        and row.get(key) != ""
+        and not _is_zero_value(row.get(key))
+        for key in keys
+    )
+
+
+def _telemetry_payload_score(payload: Any) -> int:
+    score = 0
+    for key, value in _iter_payload_scalars(payload):
+        value_text = "" if value is None else str(value)
+        if value_text == "" or _is_zero_value(value_text):
+            continue
+        key_name = key.rsplit(".", 1)[-1].lower()
+        if key_name in TELEMETRY_KEYS:
+            score += 1
+    return score
+
+
+def _is_all_field_null(payload: dict[str, Any]) -> bool:
+    return str(payload.get("allFieldIsNull")).strip().lower() == "true"
+
+
+def _is_recent_app_device_telemetry(
+    app_device: dict[str, Any],
+    *,
+    now: datetime | None,
+    max_age_seconds: int | None,
+) -> bool:
+    if max_age_seconds is None:
+        return True
+    last_alive = app_device.get("lastAlive")
+    if not isinstance(last_alive, dict):
+        return False
+    timestamp = _parse_bluetti_timestamp(last_alive.get("timestamp"))
+    if timestamp is None:
+        return False
+    if now is None:
+        now = datetime.now()
+    age_seconds = (now - timestamp).total_seconds()
+    return age_seconds <= max_age_seconds
+
+
+def _parse_bluetti_timestamp(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    value_text = str(value).strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(value_text[:19], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _hub_related_model_score(model: Any) -> int:
+    model_text = str(model or "").upper()
+    if _is_hub_related_system_model(model):
+        return 120
+    if "EL100" in model_text:
+        return 100
+    if "HA1" in model_text:
+        return 90
+    return 0
+
+
+def _is_hub_related_system_model(model: Any) -> bool:
+    model_text = str(model or "").upper()
+    return any(marker in model_text for marker in ("APEX", "AP300"))
+
+
+def _iter_payload_scalars(payload: Any, prefix: str = ""):
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            key_text = str(key)
+            nested_key = f"{prefix}.{key_text}" if prefix else key_text
+            yield from _iter_payload_scalars(value, nested_key)
+        return
+    if isinstance(payload, list):
+        for index, item in enumerate(payload, start=1):
+            item_prefix = _payload_row_prefix(item, index, prefix)
+            yield from _iter_payload_scalars(item, item_prefix)
+        return
+    if prefix:
+        yield prefix, payload
+
+
+def _payload_row_prefix(item: Any, index: int, prefix: str) -> str:
+    label = None
+    if isinstance(item, dict):
+        for key in ("portName", "name", "moduleName"):
+            value = item.get(key)
+            if value:
+                label = _redact_identifier_text(str(value))
+                break
+    row_name = label or f"row{index}"
+    return f"{prefix}.{row_name}" if prefix else row_name
+
+
+def _payload_serial_value(payload: dict[str, Any]) -> Any:
+    for key in ("sn", "deviceSn", "deviceSN", "boardSn", "mesSn", "serial"):
+        value = payload.get(key)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _normalize_serial_text(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _is_identifier_key(key: str) -> bool:
+    key_parts = {part.lower() for part in re.split(r"[^A-Za-z0-9]+", key) if part}
+    if key_parts & {"sn", "id", "mac", "uuid"}:
+        return True
+    return any(
+        marker in part
+        for part in key_parts
+        for marker in ("serial", "devicesn", "deviceid")
+    )
+
+
+def _online_value(app_device: dict[str, Any], last_alive: dict[str, Any]) -> str:
+    session_state = str(app_device.get("sessionState") or "").lower()
+    if session_state == "online":
+        return "1"
+    network_connect = app_device.get("networkConnect")
+    if str(network_connect) == "1":
+        return "1"
+    if session_state == "offline":
+        return "0"
+    if str(network_connect) == "0":
+        return "0"
+    return "1" if last_alive else "0"
+
+
+def _redact_identifier_text(value: str) -> str:
+    return re.sub(r"\b[A-Z0-9][A-Z0-9_-]{7,}\b", "<redacted>", value)
+
+
+def _binary_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    if value is None or value == "":
+        return None
+    return _state(fn_code, fn_name, "1" if str(value).lower() in {"1", "true", "online"} else "0")
+
+
+def _battery_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    return _sensor(fn_code, fn_name, value, SENSOR_TYPE_BATTERY, "%")
+
+
+def _duration_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    return _sensor(fn_code, fn_name, value, "SensorDeviceClass.DURATION", "min")
+
+
+def _energy_sensor(fn_code: str, fn_name: str, value: Any, *, unit: str = "kWh") -> dict[str, Any] | None:
+    return _sensor(fn_code, fn_name, value, SENSOR_TYPE_ENERGY, unit)
+
+
+def _power_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    return _sensor(fn_code, fn_name, value, SENSOR_TYPE_POWER, "W")
+
+
+def _voltage_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    return _sensor(fn_code, fn_name, value, SENSOR_TYPE_VOLTAGE, "V")
+
+
+def _plain_sensor(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    if value is None or value == "":
+        return None
+    return _state(fn_code, fn_name, value)
+
+
+def _switch_state(fn_code: str, fn_name: str, value: Any) -> dict[str, Any] | None:
+    if value is None or value == "":
+        return None
+    return _state(fn_code, fn_name, "1" if str(value).lower() in {"1", "true", "online"} else "0", fn_type="SWITCH")
+
+
+def _sensor(fn_code: str, fn_name: str, value: Any, sensor_type: str, unit: str) -> dict[str, Any] | None:
+    if value is None or value == "":
+        return None
+    return _state(fn_code, fn_name, value, {"sensorType": sensor_type, "unit": unit})
+
+
+def _state(
+    fn_code: str,
+    fn_name: str,
+    value: Any,
+    sensor_info: dict[str, str] | None = None,
+    fn_type: str = "SENSOR",
+) -> dict[str, Any]:
+    return {
+        "fnCode": fn_code,
+        "fnName": fn_name,
+        "fnValue": str(value),
+        "fnType": fn_type,
+        "sensorInfo": sensor_info or {},
+        "supportModeValues": [],
+    }

--- a/custom_components/bluetti/models.py
+++ b/custom_components/bluetti/models.py
@@ -201,6 +201,30 @@ class BluettiDevice:
     async def _async_update(self):
         api_client = self._api_client
 
+        if self.model == "HA1":
+            data = await api_client.get_hub_a1_product(self.device_id)
+            self.on_line = data.online
+            self.name = data.name or self.name
+
+            for s in data.stateList:
+                state_obj = self.get_state(s["fnCode"])
+                if state_obj:
+                    state_obj.fn_value = s["fnValue"]
+                else:
+                    self.states.append(
+                        BluettiState(
+                            fn_code=s.get("fnCode"),
+                            fn_name=s.get("fnName") or "",
+                            fn_value=s.get("fnValue"),
+                            fn_type=s.get("fnType"),
+                            support_mode_values=s.get("supportModeValues"),
+                            sensor_info=s.get("sensorInfo"),
+                        )
+                    )
+
+            await self.publish_updates()
+            return
+
         device_status = await api_client.get_device_status(self.device_id)
         # print(device_status.data[0])
         data = device_status.data[0]
@@ -225,6 +249,31 @@ class BluettiDevice:
             state_obj = self.get_state(s["fnCode"])
             if state_obj:
                 state_obj.fn_value = s["fnValue"]
+
+        try:
+            app_states = await api_client.get_app_device_state_overrides(self.device_id)
+        except Exception as exc:
+            __LOGGER__.debug("Unable to load app-side state overrides: %s", exc.__class__.__name__)
+            app_states = []
+
+        for s in app_states:
+            if s.get("fnCode") == "onLine":
+                self.on_line = s["fnValue"]
+                continue
+            state_obj = self.get_state(s["fnCode"])
+            if state_obj:
+                state_obj.fn_value = s["fnValue"]
+            else:
+                self.states.append(
+                    BluettiState(
+                        fn_code=s.get("fnCode"),
+                        fn_name=s.get("fnName") or "",
+                        fn_value=s.get("fnValue"),
+                        fn_type=s.get("fnType"),
+                        support_mode_values=s.get("supportModeValues"),
+                        sensor_info=s.get("sensorInfo"),
+                    )
+                )
 
         await self.publish_updates()
 

--- a/custom_components/bluetti/oauth.py
+++ b/custom_components/bluetti/oauth.py
@@ -16,9 +16,30 @@ from aiohttp import ClientSession
 import voluptuous as vol
 
 from .api.product_client import ProductClient
-from .const import DOMAIN, INTEGRATION_NAME,EVENT_TOKEN_EXPIRED,NOTIFY_ID_TOKEN_EXPIRED
+from .const import CONF_HUB_A1_SERIALS, DOMAIN, INTEGRATION_NAME,EVENT_TOKEN_EXPIRED,NOTIFY_ID_TOKEN_EXPIRED
+from .hub_a1 import HubA1LookupError, parse_hub_a1_serials
 
 __LOGGER__ = logging.getLogger(__name__)
+
+
+def _dedupe(values):
+    result = []
+    for value in values:
+        if value and value not in result:
+            result.append(value)
+    return result
+
+
+def _serialize_products(products):
+    serialized = []
+    for product in products:
+        if hasattr(product, "model_dump"):
+            serialized.append(product.model_dump())
+        elif hasattr(product, "__dict__"):
+            serialized.append(product.__dict__)
+        else:
+            serialized.append(product)
+    return serialized
 
 
 class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, domain=DOMAIN):
@@ -41,7 +62,40 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
         """Let user select devices after OAuth2 login."""
         if user_input is not None:
             # print(user_input)
-            await self._product_client.bind_devices({"bindSnList": user_input['devices']})
+            selected_devices = list(user_input.get("devices", []))
+            hub_a1_serials = parse_hub_a1_serials(user_input.get(CONF_HUB_A1_SERIALS))
+
+            if not selected_devices and not hub_a1_serials:
+                return self.async_show_form(
+                    step_id="select_devices",
+                    data_schema=self._select_devices_schema(user_input.get(CONF_HUB_A1_SERIALS, "")),
+                    errors={"base": "no_devices_available"},
+                )
+
+            hub_a1_products = []
+            try:
+                for serial in hub_a1_serials:
+                    hub_a1_products.append(await self._product_client.get_hub_a1_product(serial))
+            except HubA1LookupError as exc:
+                __LOGGER__.warning("Failed to load Hub A1 serial through app API: %s", exc)
+                return self.async_show_form(
+                    step_id="select_devices",
+                    data_schema=self._select_devices_schema(user_input.get(CONF_HUB_A1_SERIALS, "")),
+                    errors={"base": "cannot_connect"},
+                )
+            except Exception as exc:
+                __LOGGER__.warning("Failed to load Hub A1 serial through app API: %s", exc.__class__.__name__)
+                return self.async_show_form(
+                    step_id="select_devices",
+                    data_schema=self._select_devices_schema(user_input.get(CONF_HUB_A1_SERIALS, "")),
+                    errors={"base": "cannot_connect"},
+                )
+
+            if selected_devices:
+                await self._product_client.bind_devices({"bindSnList": selected_devices})
+
+            products_to_store = self._products + hub_a1_products
+            selected_device_sns = _dedupe(selected_devices + [product.sn for product in hub_a1_products])
             
             # 检查是否存在同名的集成条目
             existing_entry = None
@@ -54,14 +108,16 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                 # 合并到现有集成条目
                 existing_devices = existing_entry.options.get("devices", [])
                 existing_products = existing_entry.data.get("products", [])
+                existing_hub_a1_serials = parse_hub_a1_serials(existing_entry.options.get(CONF_HUB_A1_SERIALS))
                 
                 # 合并设备列表（去重）
-                merged_devices = list(set(existing_devices + user_input['devices']))
+                merged_devices = _dedupe(list(existing_devices) + selected_device_sns)
+                merged_hub_a1_serials = _dedupe(existing_hub_a1_serials + hub_a1_serials)
                 
                 # 合并产品数据（去重）
                 existing_product_sns = {p.get('sn') if isinstance(p, dict) else p.sn for p in existing_products}
-                new_products = [p for p in self._products if p.sn not in existing_product_sns]
-                merged_products = existing_products + [p.__dict__ if hasattr(p, '__dict__') else p for p in new_products]
+                new_products = [p for p in products_to_store if p.sn not in existing_product_sns]
+                merged_products = existing_products + _serialize_products(new_products)
                 
                 # 更新现有条目
                 self.hass.config_entries.async_update_entry(
@@ -71,7 +127,7 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                         "token": self._oauth_data["token"],
                         "products": merged_products
                     },
-                    options={"devices": merged_devices}
+                    options={"devices": merged_devices, CONF_HUB_A1_SERIALS: merged_hub_a1_serials}
                 )
                 
                 # 重新加载集成以包含新设备
@@ -85,9 +141,9 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                     data={
                         "auth_implementation": self._oauth_data["auth_implementation"],
                         "token": self._oauth_data["token"],
-                        "products": self._products
+                        "products": _serialize_products(products_to_store)
                     },
-                    options=user_input,
+                    options={"devices": selected_device_sns, CONF_HUB_A1_SERIALS: hub_a1_serials},
                 )
 
         httpSession = async_get_clientsession(self.hass)
@@ -99,7 +155,7 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
         # print(products.data)
 
         self._product_client = product_client
-        self._products = products.data
+        self._products = products.data or []
 
         # 获取已集成的设备列表
         integrated_devices = set()
@@ -109,9 +165,10 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
         # 过滤掉已经集成过的设备
         available_devices = {
             prod.sn: f"{prod.name} - {prod.sn}"   
-            for prod in products.data
+            for prod in self._products
             if prod.sn not in integrated_devices
         }
+        self._available_devices = available_devices
 
 
         # reconfigure token 
@@ -127,25 +184,21 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
             return self.async_abort(reason="success")
 
         # 如果没有可用设备，显示错误
-        if not products.data:
-            return self.async_abort(reason="no_devices_available")
-        
-        # 已全部集成
-        if not available_devices:
-            return self.async_abort(reason="all_devices_exists")
-
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    "devices",
-                    default=list(available_devices.keys())
-                ): cv.multi_select(available_devices)
-            }
-        )
-
         return self.async_show_form(
             step_id="select_devices",
-            data_schema=schema,
+            data_schema=self._select_devices_schema(),
+        )
+
+    def _select_devices_schema(self, hub_a1_serials: str = ""):
+        available_devices = getattr(self, "_available_devices", {})
+        return vol.Schema(
+            {
+                vol.Optional(
+                    "devices",
+                    default=list(available_devices.keys())
+                ): cv.multi_select(available_devices),
+                vol.Optional(CONF_HUB_A1_SERIALS, default=hub_a1_serials): str,
+            }
         )
 
     async def async_step_reconfigure(self, user_input=None):

--- a/custom_components/bluetti/sensor.py
+++ b/custom_components/bluetti/sensor.py
@@ -53,6 +53,16 @@ SENSOR_MAP: dict[str, BaseSensorMetaInfo] = {
         "device_class":SensorDeviceClass.POWER,
         "state_class":SensorStateClass.MEASUREMENT,
         "unit": "W"
+    },
+    "SensorDeviceClass.VOLTAGE":{
+        "device_class":SensorDeviceClass.VOLTAGE,
+        "state_class":SensorStateClass.MEASUREMENT,
+        "unit": "V"
+    },
+    "SensorDeviceClass.ENERGY":{
+        "device_class":SensorDeviceClass.ENERGY,
+        "state_class":SensorStateClass.TOTAL_INCREASING,
+        "unit": "kWh"
     }
 }
 
@@ -61,6 +71,18 @@ BINARY_SENSOR_MAP = {
     "onLine": {
         "device_class": BinarySensorDeviceClass.CONNECTIVITY,
         "name": "Online",
+    },
+    "HubA1AcSwitch": {
+        "device_class": None,
+        "name": "AC Switch",
+    },
+    "HubA1DcSwitch": {
+        "device_class": None,
+        "name": "DC Switch",
+    },
+    "HubA1GridSwitch": {
+        "device_class": None,
+        "name": "Grid Switch",
     }
 }
 

--- a/custom_components/bluetti/strings.json
+++ b/custom_components/bluetti/strings.json
@@ -3,6 +3,14 @@
     "step": {
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
+      },
+      "select_devices": {
+        "title": "Select BLUETTI devices",
+        "data": {
+          "devices": "Devices",
+          "hub_a1_serials": "Hub A1 serial numbers"
+        },
+        "description": "Select visible BLUETTI devices and optionally enter Hub A1 serial numbers separated by commas, spaces, or new lines."
       }
     },
     "abort": {
@@ -21,6 +29,10 @@
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "no_devices_available": "Select at least one device or enter a Hub A1 serial number."
     }
   }
 }

--- a/custom_components/bluetti/translations/en.json
+++ b/custom_components/bluetti/translations/en.json
@@ -17,9 +17,21 @@
         "create_entry": {
             "default": "Successfully authenticated"
         },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "no_devices_available": "Select at least one device or enter a Hub A1 serial number."
+        },
         "step": {
             "pick_implementation": {
                 "title": "Pick authentication method"
+            },
+            "select_devices": {
+                "data": {
+                    "devices": "Devices",
+                    "hub_a1_serials": "Hub A1 serial numbers"
+                },
+                "description": "Select visible BLUETTI devices and optionally enter Hub A1 serial numbers separated by commas, spaces, or new lines.",
+                "title": "Select BLUETTI devices"
             }
         }
     }

--- a/tests/test_bluetti_capture.py
+++ b/tests/test_bluetti_capture.py
@@ -1,0 +1,469 @@
+import contextlib
+import io
+import importlib.util
+import multiprocessing
+import pathlib
+import tempfile
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "tools" / "bluetti_capture.py"
+TEST_HUB_SERIAL = "TEST-HUB-A1-SERIAL"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("bluetti_capture", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("bluetti_capture module is missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_wait_for_oauth_code(module_path, url_file, queue):
+    spec = importlib.util.spec_from_file_location("bluetti_capture_child", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class FakeOAuthServer:
+        oauth_result = None
+        socket = None
+
+        def server_close(self):
+            pass
+
+    module.OAuthCallbackServer = lambda *args, **kwargs: FakeOAuthServer()
+
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            module.wait_for_oauth_code(
+                "127.0.0.1",
+                0,
+                "/callback",
+                module.DEFAULT_CLIENT_ID,
+                0,
+                False,
+                pathlib.Path(url_file),
+            )
+    except Exception as exc:
+        queue.put((type(exc).__name__, str(exc)))
+    else:
+        queue.put(("ok", ""))
+
+
+class BluettiCaptureTests(unittest.TestCase):
+    def setUp(self):
+        self.capture = load_module()
+
+    def test_redacts_sensitive_tokens_and_device_identifiers(self):
+        payload = {
+            "access_token": "access-token-value",
+            "refresh_token": "refresh-token-value",
+            "authorization": "secret-header",
+            "data": [
+                {
+                    "sn": "AP300SERIAL123",
+                    "name": "Garage Apex",
+                    "model": "AP300",
+                    "stateList": [
+                        {
+                            "fnCode": "SOC",
+                            "fnName": "Battery SOC",
+                            "fnType": "SENSOR",
+                            "fnValue": "87",
+                            "sensorInfo": {"unit": "%"},
+                        }
+                    ],
+                }
+            ],
+        }
+
+        redacted = self.capture.redact_payload(payload)
+
+        self.assertEqual(redacted["access_token"], "<redacted>")
+        self.assertEqual(redacted["refresh_token"], "<redacted>")
+        self.assertEqual(redacted["authorization"], "<redacted>")
+        device = redacted["data"][0]
+        self.assertNotEqual(device["sn"], "AP300SERIAL123")
+        self.assertTrue(device["sn"].startswith("sha256:"))
+        self.assertEqual(device["name"], "<redacted-name>")
+        self.assertEqual(device["model"], "AP300")
+        self.assertEqual(device["stateList"][0]["fnName"], "Battery SOC")
+
+    def test_redacts_serials_used_as_device_state_keys(self):
+        payload = {
+            "device_states": {
+                "AP300SERIAL123": {
+                    "msgCode": 0,
+                    "data": [{"sn": "AP300SERIAL123", "stateList": []}],
+                }
+            }
+        }
+
+        redacted = self.capture.redact_payload(payload)
+
+        keys = list(redacted["device_states"].keys())
+        self.assertEqual(len(keys), 1)
+        self.assertNotEqual(keys[0], "AP300SERIAL123")
+        self.assertTrue(keys[0].startswith("sha256:"))
+        record = redacted["device_states"][keys[0]]["data"][0]
+        self.assertEqual(record["sn"], keys[0])
+
+    def test_redacts_serials_embedded_in_probe_query_keys(self):
+        payload = {
+            "probes": {
+                "/api/blusmartprod/device/basic/v1/deviceRemoteSearch?deviceSn=AP300SERIAL123": {
+                    "msgCode": 0,
+                    "data": {"sn": "AP300SERIAL123"},
+                }
+            }
+        }
+
+        redacted = self.capture.redact_payload(payload)
+
+        keys = list(redacted["probes"].keys())
+        self.assertEqual(len(keys), 1)
+        self.assertIn("deviceSn=sha256%3A", keys[0])
+        self.assertNotIn("AP300SERIAL123", keys[0])
+
+    def test_redacts_extended_app_device_identifier_fields(self):
+        payload = {
+            "boardSn": "BOARD123456",
+            "subSn": "SUB123456",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "addressId": "address-identifier",
+            "deviceId": "device-identifier",
+            "mesSn": "MES1234567890",
+            "userId": "user-identifier",
+        }
+
+        redacted = self.capture.redact_payload(payload)
+
+        for key in payload:
+            self.assertNotEqual(redacted[key], payload[key])
+            self.assertTrue(redacted[key].startswith("sha256:"))
+
+    def test_summarizes_state_descriptors_by_device(self):
+        capture = {
+            "devices": {
+                "data": [
+                    {"sn": "AP300SERIAL123", "name": "Garage Apex", "model": "AP300"}
+                ]
+            },
+            "device_states": {
+                "AP300SERIAL123": {
+                    "data": [
+                        {
+                            "sn": "AP300SERIAL123",
+                            "model": "AP300",
+                            "stateList": [
+                                {
+                                    "fnCode": "SOC",
+                                    "fnName": "Battery SOC",
+                                    "fnType": "SENSOR",
+                                    "fnValue": "87",
+                                    "sensorInfo": {"unit": "%"},
+                                },
+                                {
+                                    "fnCode": "SetCtrlWorkMode",
+                                    "fnName": "Work Mode",
+                                    "fnType": "MODE",
+                                    "fnValue": "1",
+                                    "supportModeValues": [
+                                        {"code": "1", "name": "Backup"},
+                                        {"code": "2", "name": "Self Consumption"},
+                                    ],
+                                },
+                            ],
+                        }
+                    ]
+                }
+            },
+        }
+
+        summary = self.capture.summarize_capture(capture)
+
+        self.assertEqual(summary["device_count"], 1)
+        device = summary["devices"][0]
+        self.assertEqual(device["model"], "AP300")
+        self.assertTrue(device["serial_hash"].startswith("sha256:"))
+        self.assertEqual(device["state_count"], 2)
+        self.assertEqual(
+            device["functions"][0],
+            {
+                "fnCode": "SOC",
+                "fnName": "Battery SOC",
+                "fnType": "SENSOR",
+                "value_shape": "numeric-string",
+                "sensorInfo": {"unit": "%"},
+                "supportModeValues": [],
+            },
+        )
+        self.assertEqual(device["functions"][1]["supportModeValues"][0]["name"], "Backup")
+
+    def test_summarizes_state_only_extra_serials_missing_from_devices(self):
+        capture = {
+            "devices": {"msgCode": 0, "data": []},
+            "device_states": {
+                TEST_HUB_SERIAL: {
+                    "msgCode": 0,
+                    "message": "OK",
+                    "data": [
+                        {
+                            "sn": TEST_HUB_SERIAL,
+                            "online": "0",
+                            "isBindByCurUser": "0",
+                            "stateList": [],
+                        }
+                    ],
+                }
+            },
+        }
+
+        summary = self.capture.summarize_capture(capture)
+
+        self.assertEqual(summary["device_count"], 1)
+        device = summary["devices"][0]
+        self.assertFalse(device["in_devices_response"])
+        self.assertEqual(device["source"], "deviceStates")
+        self.assertEqual(device["isBindByCurUser"], "0")
+        self.assertEqual(device["state_response_msgCode"], 0)
+        self.assertEqual(device["state_count"], 0)
+
+    def test_oauth_wait_writes_url_file_and_times_out_promptly(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            url_file = pathlib.Path(tmpdir) / "oauth-url.txt"
+            ctx = multiprocessing.get_context("fork")
+            queue = ctx.Queue()
+            process = ctx.Process(
+                target=run_wait_for_oauth_code,
+                args=(str(MODULE_PATH), str(url_file), queue),
+            )
+
+            process.start()
+            process.join(3)
+            if process.is_alive():
+                process.terminate()
+                process.join(1)
+                self.fail("OAuth wait did not time out promptly")
+
+            self.assertTrue(url_file.exists())
+            self.assertIn("/oauth2/grant?", url_file.read_text(encoding="utf-8"))
+            status, message = queue.get_nowait()
+            self.assertEqual(status, "RuntimeError")
+            self.assertIn("Timed out waiting", message)
+
+    def test_capture_devices_queries_extra_serials_missing_from_devices_response(self):
+        calls = []
+
+        def fake_get_json(path, access_token, params=None):
+            calls.append((path, params))
+            if path == self.capture.DEVICES_PATH:
+                return {
+                    "msgCode": 0,
+                    "data": [
+                        {"sn": "RETURNED123", "model": "FP", "stateList": []}
+                    ],
+                }
+            return {
+                "msgCode": 0,
+                "data": [
+                    {
+                        "sn": params["sns"],
+                        "model": "AP300",
+                        "stateList": [
+                            {"fnCode": "SOC", "fnType": "SENSOR", "fnValue": "88"}
+                        ],
+                    }
+                ],
+            }
+
+        capture = self.capture.capture_devices(
+            "token-value",
+            extra_serials=["MISSING456", "RETURNED123"],
+            getter=fake_get_json,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                (self.capture.DEVICES_PATH, None),
+                (self.capture.DEVICE_STATES_PATH, {"sns": "RETURNED123"}),
+                (self.capture.DEVICE_STATES_PATH, {"sns": "MISSING456"}),
+            ],
+        )
+        self.assertIn("MISSING456", capture["device_states"])
+
+    def test_capture_devices_can_probe_read_only_app_endpoints(self):
+        calls = []
+
+        def fake_get_json(path, access_token, params=None):
+            calls.append((path, params))
+            if path == self.capture.DEVICES_PATH:
+                return {"msgCode": 0, "data": []}
+            return {"msgCode": 0, "data": [{"deviceType": "HubA1"}]}
+
+        capture = self.capture.capture_devices(
+            "token-value",
+            probe_get_paths=["/api/blusmartprod/user/space/v1/getSpaceDeviceList"],
+            getter=fake_get_json,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                (self.capture.DEVICES_PATH, None),
+                ("/api/blusmartprod/user/space/v1/getSpaceDeviceList", None),
+            ],
+        )
+        self.assertEqual(
+            capture["probes"]["/api/blusmartprod/user/space/v1/getSpaceDeviceList"]["data"][0]["deviceType"],
+            "HubA1",
+        )
+
+    def test_known_read_probe_paths_include_serialized_aecc_variants(self):
+        args = self.capture.parse_args(
+            [
+                "--probe-known-read",
+                "--extra-sn",
+                TEST_HUB_SERIAL,
+            ]
+        )
+
+        paths = self.capture.load_probe_paths(args)
+
+        self.assertIn("/api/blusmartprod/device/group/v1/homeDevices", paths)
+        self.assertIn(
+            f"/api/bluiotdata/aecc/v1/getDeviceRealTimeData?sn={TEST_HUB_SERIAL}",
+            paths,
+        )
+        self.assertIn(
+            f"/api/bluiotdata/aecc/v1/getDeviceRealTimeData?deviceSn={TEST_HUB_SERIAL}",
+            paths,
+        )
+
+    def test_probe_errors_are_recorded_without_aborting_capture(self):
+        calls = []
+
+        def fake_get_json(path, access_token, params=None):
+            calls.append((path, params))
+            if path == self.capture.DEVICES_PATH:
+                return {"msgCode": 0, "data": []}
+            if path == "/api/blusmartprod/device/group/v1/findDevicePage":
+                raise RuntimeError("BLUETTI HTTP error: 500")
+            return {"msgCode": 0, "data": [{"deviceType": "HubA1"}]}
+
+        capture = self.capture.capture_devices(
+            "token-value",
+            probe_get_paths=[
+                "/api/blusmartprod/device/group/v1/findDevicePage",
+                "/api/blusmartprod/user/space/v1/getSpaceDeviceList",
+            ],
+            getter=fake_get_json,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                (self.capture.DEVICES_PATH, None),
+                ("/api/blusmartprod/device/group/v1/findDevicePage", None),
+                ("/api/blusmartprod/user/space/v1/getSpaceDeviceList", None),
+            ],
+        )
+        failed_probe = capture["probes"]["/api/blusmartprod/device/group/v1/findDevicePage"]
+        self.assertFalse(failed_probe["ok"])
+        self.assertIn("500", failed_probe["error"])
+        successful_probe = capture["probes"]["/api/blusmartprod/user/space/v1/getSpaceDeviceList"]
+        self.assertEqual(successful_probe["data"][0]["deviceType"], "HubA1")
+
+    def test_capture_devices_can_probe_read_only_post_endpoints(self):
+        calls = []
+
+        def fake_get_json(path, access_token, params=None):
+            calls.append(("GET", path, params))
+            if path == self.capture.DEVICES_PATH:
+                return {"msgCode": 0, "data": []}
+            return {"msgCode": 0, "data": []}
+
+        def fake_post_json(path, access_token, payload):
+            calls.append(("POST", path, payload))
+            return {"msgCode": 0, "data": [{"model": "HA1"}]}
+
+        capture = self.capture.capture_devices(
+            "token-value",
+            probe_post_requests=[
+                (
+                    "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+                    {"deviceSn": TEST_HUB_SERIAL},
+                )
+            ],
+            getter=fake_get_json,
+            poster=fake_post_json,
+        )
+
+        self.assertEqual(
+            calls,
+            [
+                ("GET", self.capture.DEVICES_PATH, None),
+                (
+                    "POST",
+                    "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+                    {"deviceSn": TEST_HUB_SERIAL},
+                ),
+            ],
+        )
+        probe_key = (
+            "POST /api/bluiotdata/aecc/v1/getDeviceRealTimeData "
+            f"deviceSn={self.capture.stable_hash(TEST_HUB_SERIAL)}"
+        )
+        self.assertEqual(capture["probes"][probe_key]["response"]["data"][0]["model"], "HA1")
+
+    def test_known_read_probe_requests_include_serial_post_variants(self):
+        args = self.capture.parse_args(
+            [
+                "--probe-known-read",
+                "--extra-sn",
+                TEST_HUB_SERIAL,
+            ]
+        )
+
+        requests = self.capture.load_probe_post_requests(args)
+
+        self.assertIn(
+            (
+                "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+                {"deviceSn": TEST_HUB_SERIAL},
+            ),
+            requests,
+        )
+        self.assertIn(
+            (
+                "/api/blusmartprod/aecc/command/v1/querySystemPowerData",
+                {"deviceSn": TEST_HUB_SERIAL},
+            ),
+            requests,
+        )
+
+    def test_loads_explicit_post_json_probe_requests(self):
+        args = self.capture.parse_args(
+            [
+                "--probe-post-json",
+                f'/api/bluiotdata/aecc/v1/getDeviceRealTimeData={{"deviceSn":"{TEST_HUB_SERIAL}"}}',
+            ]
+        )
+
+        requests = self.capture.load_probe_post_requests(args)
+
+        self.assertEqual(
+            requests,
+            [
+                (
+                    "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+                    {"deviceSn": TEST_HUB_SERIAL},
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debug_logging_contract.py
+++ b/tests/test_debug_logging_contract.py
@@ -1,0 +1,69 @@
+import ast
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+DIAGNOSTIC_LOG_SNIPPETS = (
+    "BLUETTI setup product summary",
+    "BLUETTI periodic runtime state summary",
+    "BLUETTI setup runtime state summary",
+    "BLUETTI app state override summary",
+    "BLUETTI app direct lookup summary",
+    "BLUETTI app selected home-device payload",
+    "BLUETTI app home devices summary",
+    "Hub A1 app lookup summary",
+    "Hub A1 selected field source summary",
+    "Hub A1 app home serial summary",
+    "Hub A1 related app telemetry fallback summary",
+    "Hub A1 built state summary",
+    "Hub A1 optional telemetry summary",
+)
+
+
+def _log_messages(source: str, level: str) -> set[str]:
+    tree = ast.parse(source)
+    messages: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != level:
+            continue
+        if not node.args:
+            continue
+        message = node.args[0]
+        if isinstance(message, ast.Constant) and isinstance(message.value, str):
+            messages.add(message.value)
+    return messages
+
+
+class DebugLoggingContractTests(unittest.TestCase):
+    def test_diagnostic_summaries_are_debug_only(self):
+        init_source = (ROOT / "custom_components" / "bluetti" / "__init__.py").read_text(
+            encoding="utf-8"
+        )
+        product_client_source = (
+            ROOT / "custom_components" / "bluetti" / "api" / "product_client.py"
+        ).read_text(encoding="utf-8")
+        sources = f"{init_source}\n{product_client_source}"
+
+        warning_messages = _log_messages(sources, "warning")
+        debug_messages = _log_messages(sources, "debug")
+
+        for snippet in DIAGNOSTIC_LOG_SNIPPETS:
+            self.assertFalse(
+                any(snippet in message for message in warning_messages),
+                f"{snippet!r} must not be logged at warning level",
+            )
+            self.assertTrue(
+                any(snippet in message for message in debug_messages),
+                f"{snippet!r} must remain available at debug level",
+            )
+
+        self.assertIn("isEnabledFor(logging.DEBUG)", sources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hub_a1.py
+++ b/tests/test_hub_a1.py
@@ -1,0 +1,719 @@
+import importlib.util
+import hashlib
+import pathlib
+import unittest
+from datetime import datetime
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "bluetti" / "hub_a1.py"
+TEST_HUB_SERIAL = "TEST-HUB-A1-SERIAL"
+TEST_APEX_SERIAL = "TEST-APEX-SERIAL1"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("hub_a1", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("hub_a1 module is missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class HubA1Tests(unittest.TestCase):
+    def setUp(self):
+        self.hub_a1 = load_module()
+
+    def test_parse_hub_a1_serials_splits_commas_lines_and_deduplicates(self):
+        serials = self.hub_a1.parse_hub_a1_serials(
+            f" {TEST_HUB_SERIAL}, {TEST_APEX_SERIAL}\n{TEST_HUB_SERIAL}  "
+        )
+
+        self.assertEqual(serials, [TEST_HUB_SERIAL, TEST_APEX_SERIAL])
+
+    def test_parse_hub_a1_serials_ignores_friendly_name_words(self):
+        serials = self.hub_a1.parse_hub_a1_serials(
+            f"Hub A1,HA1,A1,{TEST_HUB_SERIAL}"
+        )
+
+        self.assertEqual(serials, [TEST_HUB_SERIAL])
+
+    def test_invalid_cached_hub_a1_product_detects_name_fragments(self):
+        self.assertTrue(self.hub_a1.is_invalid_hub_a1_product({"model": "HA1", "sn": "Hub"}))
+        self.assertTrue(self.hub_a1.is_invalid_hub_a1_product({"model": "HA1", "sn": "A1"}))
+        self.assertFalse(self.hub_a1.is_invalid_hub_a1_product({"model": "HA1", "sn": TEST_HUB_SERIAL}))
+        self.assertFalse(self.hub_a1.is_invalid_hub_a1_product({"model": "FP", "sn": "Hub"}))
+
+    def test_build_hub_a1_product_data_uses_app_identity_and_telemetry(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={
+                "sn": TEST_HUB_SERIAL,
+                "name": "Garage Hub",
+                "model": "HA1",
+                "sessionState": "Online",
+                "batSOC": "9",
+                "powerAcOut": 2536,
+                "powerGridIn": 2452,
+                "powerPvIn": 0,
+                "powerDcOut": 0,
+            },
+            realtime={
+                "batterySoc": "9",
+                "powerBatteryCharge": "0",
+                "powerGridIn": "2452",
+                "powerLoadOut": "2536",
+                "powerPvIn": "0",
+                "meterTotalEnergy": "12.3",
+            },
+            last_alive={
+                "batterySoh": "12",
+                "batteryVoltage": "515.6",
+                "acSwitch": "1",
+                "dcSwitch": "0",
+                "gridSwitch": "0",
+                "dcTotalEnergy": "4.5",
+            },
+            pv_details=[
+                {"portName": "PV1", "power": "0", "voltage": "0"},
+                {"portName": "PV2", "power": "0", "voltage": "0"},
+            ],
+        )
+
+        self.assertEqual(product["sn"], TEST_HUB_SERIAL)
+        self.assertEqual(product["name"], "Garage Hub")
+        self.assertEqual(product["model"], "HA1")
+        self.assertEqual(product["online"], "1")
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1BatterySoc"]["fnValue"], "9")
+        self.assertEqual(states_by_code["HubA1BatterySoc"]["sensorInfo"]["unit"], "%")
+        self.assertNotIn("HubA1BatterySoh", states_by_code)
+        self.assertEqual(states_by_code["HubA1AcPowerOut"]["fnValue"], "2536")
+        self.assertEqual(states_by_code["HubA1GridPowerIn"]["fnValue"], "2452")
+        self.assertEqual(states_by_code["HubA1BatteryVoltage"]["sensorInfo"]["unit"], "V")
+        self.assertNotIn("HubA1Pv1Power", states_by_code)
+        self.assertNotIn("HubA1Pv2Voltage", states_by_code)
+        self.assertEqual(states_by_code["HubA1AcSwitch"]["fnType"], "SENSOR")
+        self.assertEqual(states_by_code["onLine"]["fnValue"], "1")
+
+    def test_build_hub_a1_product_data_prefers_realtime_over_top_level_zero_placeholders(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={
+                "sn": TEST_HUB_SERIAL,
+                "name": "Garage Hub",
+                "model": "HA1",
+                "sessionState": "Online",
+                "batSOC": "0",
+                "powerAcOut": 0,
+                "powerGridIn": 0,
+                "powerPvIn": 0,
+            },
+            realtime={
+                "batterySoc": "89",
+                "powerLoadOut": "128",
+                "powerGridIn": "12",
+                "powerPvIn": "76",
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1BatterySoc"]["fnValue"], "89")
+        self.assertEqual(states_by_code["HubA1AcPowerOut"]["fnValue"], "128")
+        self.assertEqual(states_by_code["HubA1GridPowerIn"]["fnValue"], "12")
+        self.assertEqual(states_by_code["HubA1PvPowerIn"]["fnValue"], "76")
+
+    def test_build_hub_a1_product_data_uses_direct_app_values_over_zero_optional_telemetry(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={
+                "sn": TEST_HUB_SERIAL,
+                "name": "Garage Hub",
+                "model": "HA1",
+                "sessionState": "Online",
+                "batSOC": "9",
+                "powerAcOut": 2536,
+                "powerGridIn": 2452,
+                "powerPvIn": 0,
+                "powerDcOut": 0,
+            },
+            realtime={
+                "batterySoc": "0",
+                "powerLoadOut": "0",
+                "powerGridIn": "0",
+                "powerPvIn": "0",
+            },
+            last_alive={
+                "allFieldIsNull": True,
+                "batterySoc": "0",
+                "powerAcOut": "0",
+                "powerGridIn": "0",
+                "powerPvIn": "0",
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1BatterySoc"]["fnValue"], "9")
+        self.assertEqual(states_by_code["HubA1AcPowerOut"]["fnValue"], "2536")
+        self.assertEqual(states_by_code["HubA1GridPowerIn"]["fnValue"], "2452")
+        self.assertEqual(states_by_code["HubA1PvPowerIn"]["fnValue"], "0")
+
+    def test_build_hub_a1_product_data_uses_last_alive_grid_alias(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={
+                "sn": TEST_HUB_SERIAL,
+                "name": "Garage Hub",
+                "model": "HA1",
+                "sessionState": "Online",
+                "powerGridIn": "0",
+            },
+            realtime={"powerGridIn": "0"},
+            last_alive={"powerFeedBack": "2452"},
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1GridPowerIn"]["fnValue"], "2452")
+
+    def test_build_hub_a1_product_data_prefers_nonzero_last_alive_over_realtime_zero(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={"sn": TEST_HUB_SERIAL, "name": "Garage Hub", "model": "HA1"},
+            realtime={
+                "powerBatteryCharge": "0",
+                "meterTotalEnergy": "0",
+            },
+            last_alive={
+                "powerBatteryCharge": "42",
+                "meterTotalEnergy": "13.7",
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1BatteryChargePower"]["fnValue"], "42")
+        self.assertNotIn("HubA1MeterTotalEnergy", states_by_code)
+
+    def test_build_hub_a1_product_data_exposes_mirrored_pack_total_once_as_charge_energy(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={"sn": TEST_HUB_SERIAL, "name": "Garage Hub", "model": "HA1"},
+            last_alive={
+                "packTotalChgEnergy": "52975.0",
+                "packTotalDsgEnergy": "52975.0",
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1PackTotalChargeEnergy"]["fnValue"], "529.75")
+        self.assertEqual(states_by_code["HubA1PackTotalChargeEnergy"]["fnName"], "Battery Total Charge Energy")
+        self.assertEqual(states_by_code["HubA1PackTotalChargeEnergy"]["sensorInfo"]["unit"], "kWh")
+        self.assertNotIn("HubA1PackTotalDischargeEnergy", states_by_code)
+
+    def test_build_hub_a1_product_data_ignores_discharge_pack_total_even_when_divergent(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={"sn": TEST_HUB_SERIAL, "name": "Garage Hub", "model": "HA1"},
+            last_alive={
+                "packTotalChgEnergy": "52975.0",
+                "packTotalDsgEnergy": "52970.0",
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertEqual(states_by_code["HubA1PackTotalChargeEnergy"]["fnValue"], "529.75")
+        self.assertNotIn("HubA1PackTotalDischargeEnergy", states_by_code)
+
+    def test_build_hub_a1_product_data_keeps_detail_rows_with_nonzero_readings(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={"sn": TEST_HUB_SERIAL, "name": "Garage Hub", "model": "HA1"},
+            pv_details=[
+                {"portName": "PV1", "power": "0", "voltage": "0"},
+                {"portName": "PV2", "power": "76", "voltage": "42"},
+            ],
+            load_details=[{"portName": "L1", "power": "128", "voltage": "120"}],
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertNotIn("HubA1Pv1Power", states_by_code)
+        self.assertEqual(states_by_code["HubA1Pv2Power"]["fnValue"], "76")
+        self.assertEqual(states_by_code["HubA1Pv2Voltage"]["fnValue"], "42")
+        self.assertEqual(states_by_code["HubA1Load1Power"]["fnValue"], "128")
+
+    def test_summarize_hub_a1_field_sources_reports_selected_aliases(self):
+        summary = self.hub_a1.summarize_hub_a1_field_sources(
+            app_device={"powerGridIn": "0"},
+            realtime={"powerGridIn": "0"},
+            last_alive={
+                "powerFeedBack": "2452",
+                "powerInvTotal": "-485",
+                "packTotalChgEnergy": "55029.0",
+                "packTotalDsgEnergy": "55029.0",
+            },
+        )
+
+        self.assertIn("GridPowerIn=lastAlive.powerFeedBack:2452", summary)
+        self.assertIn("InverterTotalPower=lastAlive.powerInvTotal:-485", summary)
+        self.assertIn("BatterySoc=none", summary)
+        self.assertIn("BatteryTotalChargeEnergy=lastAlive.packTotalChgEnergy:55029.0", summary)
+        self.assertIn("PackTotalDischargeEnergy=ignored_displayed_as_charge:lastAlive.packTotalDsgEnergy:55029.0", summary)
+
+    def test_build_app_device_state_overrides_prefers_last_alive_for_apex_zero_fields(self):
+        states = self.hub_a1.build_app_device_state_overrides(
+            {
+                "model": "EL100V2",
+                "sessionState": "Offline",
+                "networkConnect": 1,
+                "batSOC": "0",
+                "powerAcOut": 0,
+                "powerDcOut": 0,
+                "powerGridIn": 0,
+                "powerPvIn": 0,
+                "lastAlive": {
+                    "batterySoc": "89",
+                    "powerAcOut": "128",
+                    "powerDcOut": "0",
+                    "powerGridIn": "0",
+                    "powerPvIn": "76",
+                    "chgFullTime": "5994",
+                    "acSwitch": "1",
+                    "dcSwitch": "0",
+                },
+            }
+        )
+
+        states_by_code = {state["fnCode"]: state for state in states}
+        self.assertEqual(states_by_code["onLine"]["fnValue"], "1")
+        self.assertEqual(states_by_code["SOC"]["fnValue"], "89")
+        self.assertEqual(states_by_code["ACLoadAllTotalPower"]["fnValue"], "128")
+        self.assertEqual(states_by_code["DCLoadAllTotalPower"]["fnValue"], "0")
+        self.assertEqual(states_by_code["PVAllTotalPower"]["fnValue"], "76")
+        self.assertEqual(states_by_code["ChgFullTime"]["fnValue"], "5994")
+        self.assertEqual(states_by_code["SetCtrlAc"]["fnValue"], "1")
+        self.assertEqual(states_by_code["SetCtrlDc"]["fnValue"], "0")
+
+    def test_build_app_device_state_overrides_scales_pack_totals_as_centi_kwh(self):
+        states = self.hub_a1.build_app_device_state_overrides(
+            {
+                "model": "FP",
+                "sessionState": "Online",
+                "lastAlive": {
+                    "packTotalChgEnergy": "2344.0",
+                    "packTotalDsgEnergy": "2230.0",
+                },
+            }
+        )
+
+        states_by_code = {state["fnCode"]: state for state in states}
+        self.assertEqual(states_by_code["PackTotalChargeEnergy"]["fnValue"], "23.44")
+        self.assertEqual(states_by_code["PackTotalChargeEnergy"]["sensorInfo"]["unit"], "kWh")
+        self.assertEqual(states_by_code["PackTotalDischargeEnergy"]["fnValue"], "22.30")
+        self.assertEqual(states_by_code["PackTotalDischargeEnergy"]["sensorInfo"]["unit"], "kWh")
+
+    def test_select_preferred_app_device_payload_uses_home_last_alive_over_direct_zeros(self):
+        direct = {
+            "sn": TEST_APEX_SERIAL,
+            "model": "EL100V2",
+            "networkConnect": 1,
+            "batSOC": "0",
+            "powerAcOut": "0",
+            "powerPvIn": "0",
+        }
+        home = {
+            "sn": TEST_APEX_SERIAL,
+            "model": "EL100V2",
+            "networkConnect": 1,
+            "batSOC": "0",
+            "powerAcOut": "0",
+            "powerPvIn": "0",
+            "lastAlive": {
+                "allFieldIsNull": False,
+                "batterySoc": "89",
+                "powerAcOut": "128",
+                "powerPvIn": "76",
+            },
+        }
+
+        selected = self.hub_a1.select_preferred_app_device_payload(
+            TEST_APEX_SERIAL,
+            direct,
+            [home],
+        )
+
+        self.assertIs(selected, home)
+
+    def test_select_preferred_app_device_payload_ignores_stale_home_last_alive(self):
+        direct = {
+            "sn": TEST_APEX_SERIAL,
+            "model": "EL100V2",
+            "networkConnect": 1,
+            "batSOC": "0",
+            "powerAcOut": "0",
+            "powerPvIn": "0",
+        }
+        home = {
+            "sn": TEST_APEX_SERIAL,
+            "model": "EL100V2",
+            "networkConnect": 1,
+            "lastAlive": {
+                "allFieldIsNull": False,
+                "timestamp": "2026-07-04 13:00:00",
+                "batterySoc": "89",
+                "powerAcOut": "128",
+                "powerPvIn": "76",
+            },
+        }
+
+        selected = self.hub_a1.select_preferred_app_device_payload(
+            TEST_APEX_SERIAL,
+            direct,
+            [home],
+            now=datetime(2026, 7, 4, 14, 0, 0),
+            max_age_seconds=900,
+        )
+
+        self.assertIs(selected, direct)
+
+    def test_select_hub_a1_related_app_device_ignores_fresh_fp_without_verified_relation(self):
+        fp = {
+            "sn": "TEST-FP-SERIAL",
+            "model": "FP",
+            "lastAlive": {
+                "timestamp": "2026-07-04 21:42:17",
+                "batterySoc": "65",
+                "powerAcOut": "66",
+                "powerPvIn": "12",
+            },
+        }
+
+        selected = self.hub_a1.select_hub_a1_related_app_device(
+            [fp],
+            now=datetime(2026, 7, 4, 21, 43, 0),
+            max_age_seconds=900,
+        )
+
+        self.assertEqual(selected, {})
+
+    def test_select_hub_a1_related_app_device_ignores_null_last_alive_payloads(self):
+        selected = self.hub_a1.select_hub_a1_related_app_device(
+            [
+                {
+                    "sn": TEST_APEX_SERIAL,
+                    "model": "EL100V2",
+                    "lastAlive": {
+                        "allFieldIsNull": True,
+                        "batterySoc": "0",
+                        "powerAcOut": "0",
+                        "powerPvIn": "0",
+                    },
+                }
+            ]
+        )
+
+        self.assertEqual(selected, {})
+
+    def test_select_hub_a1_related_app_device_ignores_stale_last_alive_payloads(self):
+        selected = self.hub_a1.select_hub_a1_related_app_device(
+            [
+                {
+                    "sn": TEST_APEX_SERIAL,
+                    "model": "EL100V2",
+                    "lastAlive": {
+                        "allFieldIsNull": False,
+                        "timestamp": "2026-07-04 13:00:00",
+                        "batterySoc": "89",
+                        "powerAcOut": "128",
+                    },
+                }
+            ],
+            now=datetime(2026, 7, 4, 14, 0, 0),
+            max_age_seconds=900,
+        )
+
+        self.assertEqual(selected, {})
+
+    def test_build_related_hub_a1_fallback_omits_apex_battery_fields(self):
+        product = self.hub_a1.build_related_hub_a1_fallback_product_data(
+            TEST_HUB_SERIAL,
+            {
+                "model": "EL100V2",
+                "networkConnect": 1,
+                "sessionState": "Online",
+                "lastAlive": {
+                    "batterySoc": "89",
+                    "batterySoh": "100",
+                    "batteryVoltage": "533",
+                    "powerAcOut": "128",
+                    "powerPvIn": "76",
+                    "acSwitch": "1",
+                },
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertNotIn("HubA1BatterySoc", states_by_code)
+        self.assertNotIn("HubA1BatterySoh", states_by_code)
+        self.assertNotIn("HubA1BatteryVoltage", states_by_code)
+        self.assertEqual(states_by_code["HubA1AcPowerOut"]["fnValue"], "128")
+        self.assertEqual(states_by_code["HubA1PvPowerIn"]["fnValue"], "76")
+        self.assertEqual(states_by_code["HubA1AcSwitch"]["fnValue"], "1")
+
+    def test_build_related_hub_a1_fallback_omits_fp_battery_fields(self):
+        product = self.hub_a1.build_related_hub_a1_fallback_product_data(
+            TEST_HUB_SERIAL,
+            {
+                "model": "FP",
+                "networkConnect": 1,
+                "sessionState": "Online",
+                "lastAlive": {
+                    "timestamp": "2026-07-04 21:42:17",
+                    "batterySoc": "44",
+                    "batterySoh": "100",
+                    "batteryVoltage": "533.0",
+                    "powerAcOut": "69",
+                    "powerPvIn": "0",
+                    "acSwitch": "1",
+                },
+            },
+        )
+
+        states_by_code = {state["fnCode"]: state for state in product["stateList"]}
+        self.assertNotIn("HubA1BatterySoc", states_by_code)
+        self.assertNotIn("HubA1BatterySoh", states_by_code)
+        self.assertNotIn("HubA1BatteryVoltage", states_by_code)
+        self.assertEqual(states_by_code["HubA1AcPowerOut"]["fnValue"], "69")
+
+    def test_build_app_device_state_overrides_returns_empty_without_app_payload(self):
+        self.assertEqual(self.hub_a1.build_app_device_state_overrides({}), [])
+        self.assertEqual(self.hub_a1.build_app_device_state_overrides(None), [])
+
+    def test_apply_state_overrides_updates_cached_zero_product_before_entity_setup(self):
+        product = {
+            "sn": TEST_APEX_SERIAL,
+            "model": "EL100V2",
+            "name": "Apex",
+            "online": "0",
+            "stateList": [
+                {
+                    "fnCode": "SOC",
+                    "fnName": "Battery Level",
+                    "fnValue": "0",
+                    "fnType": "SENSOR",
+                    "sensorInfo": {"sensorType": "SensorDeviceClass.BATTERY", "unit": "%"},
+                    "supportModeValues": [],
+                },
+                {
+                    "fnCode": "ACLoadAllTotalPower",
+                    "fnName": "Alternating Current Out Power",
+                    "fnValue": "0",
+                    "fnType": "SENSOR",
+                    "sensorInfo": {"sensorType": "SensorDeviceClass.POWER", "unit": None},
+                    "supportModeValues": [],
+                },
+                {
+                    "fnCode": "SetCtrlWorkMode",
+                    "fnName": "Working mode",
+                    "fnValue": "workmode_3",
+                    "fnType": "SELECT",
+                    "sensorInfo": {},
+                    "supportModeValues": [{"code": "workmode_3", "name": "Self-use"}],
+                },
+            ],
+        }
+        app_states = self.hub_a1.build_app_device_state_overrides(
+            {
+                "model": "EL100V2",
+                "networkConnect": 1,
+                "lastAlive": {
+                    "batterySoc": "89",
+                    "powerAcOut": "128",
+                    "acSwitch": "1",
+                },
+            }
+        )
+
+        updated = self.hub_a1.apply_app_device_state_overrides(product, app_states)
+
+        self.assertEqual(updated["online"], "1")
+        states_by_code = {state["fnCode"]: state for state in updated["stateList"]}
+        self.assertEqual(states_by_code["SOC"]["fnValue"], "89")
+        self.assertEqual(states_by_code["SOC"]["sensorInfo"]["unit"], "%")
+        self.assertEqual(states_by_code["ACLoadAllTotalPower"]["fnValue"], "128")
+        self.assertEqual(states_by_code["SetCtrlWorkMode"]["supportModeValues"][0]["name"], "Self-use")
+        self.assertEqual(states_by_code["SetCtrlAc"]["fnType"], "SWITCH")
+
+    def test_summarize_state_values_omits_serials_and_counts_nonzero_values(self):
+        summary = self.hub_a1.summarize_state_values(
+            [
+                {"fnCode": "SOC", "fnValue": "89"},
+                {"fnCode": "ACLoadAllTotalPower", "fnValue": "128"},
+                {"fnCode": "PVAllTotalPower", "fnValue": "0"},
+                {"fnCode": TEST_HUB_SERIAL, "fnValue": TEST_APEX_SERIAL},
+            ],
+            limit=3,
+        )
+
+        self.assertIn("states=4", summary)
+        self.assertIn("nonzero=3", summary)
+        self.assertIn("zero=1", summary)
+        self.assertIn("SOC=89", summary)
+        self.assertIn("ACLoadAllTotalPower=128", summary)
+        self.assertNotIn(TEST_HUB_SERIAL, summary)
+        self.assertNotIn(TEST_APEX_SERIAL, summary)
+
+    def test_has_meaningful_state_values_ignores_online_only(self):
+        self.assertFalse(
+            self.hub_a1.has_meaningful_state_values(
+                [
+                    {"fnCode": "onLine", "fnValue": "1"},
+                    {"fnCode": "HubA1BatterySoc", "fnValue": "0"},
+                    {"fnCode": "HubA1AcPowerOut", "fnValue": "0"},
+                ]
+            )
+        )
+        self.assertTrue(
+            self.hub_a1.has_meaningful_state_values(
+                [
+                    {"fnCode": "onLine", "fnValue": "1"},
+                    {"fnCode": "HubA1BatterySoc", "fnValue": "89"},
+                ]
+            )
+        )
+
+    def test_summarize_payload_values_counts_nested_values_and_redacts_identifiers(self):
+        summary = self.hub_a1.summarize_payload_values(
+            {
+                "sn": TEST_HUB_SERIAL,
+                "model": "HA1",
+                "batSOC": "0",
+                "powerAcOut": 2536,
+                "powerGridIn": "2452",
+                "powerPvIn": 0,
+                "emptyField": "",
+                "lastAlive": {
+                    "batterySoc": "9",
+                    "powerAcOut": "2536",
+                    "serialEcho": TEST_APEX_SERIAL,
+                },
+            },
+            limit=10,
+        )
+
+        self.assertIn("fields=", summary)
+        self.assertIn("nonzero=", summary)
+        self.assertIn("zero=2", summary)
+        self.assertIn("empty=1", summary)
+        self.assertIn("powerAcOut=2536", summary)
+        self.assertIn("lastAlive.batterySoc=9", summary)
+        self.assertNotIn("serialEcho", summary)
+        self.assertNotIn(TEST_HUB_SERIAL, summary)
+        self.assertNotIn(TEST_APEX_SERIAL, summary)
+
+    def test_summarize_payload_values_handles_detail_rows_without_dumping_payloads(self):
+        summary = self.hub_a1.summarize_payload_values(
+            [
+                {"portName": "PV1", "power": "0", "voltage": "0"},
+                {"portName": "PV2", "power": "76", "voltage": "42.1"},
+            ],
+            limit=3,
+        )
+
+        self.assertIn("rows=2", summary)
+        self.assertIn("fields=6", summary)
+        self.assertIn("zero=2", summary)
+        self.assertIn("PV2.power=76", summary)
+        self.assertNotIn("raw", summary.lower())
+
+    def test_summarize_serial_identity_hashes_without_exposing_value(self):
+        summary = self.hub_a1.summarize_serial_identity(f" {TEST_HUB_SERIAL} ")
+        digest = hashlib.sha256(TEST_HUB_SERIAL.encode("utf-8")).hexdigest()[:16]
+
+        self.assertIn("len=18", summary)
+        self.assertIn(f"sha256={digest}", summary)
+        self.assertNotIn(TEST_HUB_SERIAL, summary)
+
+    def test_summarize_app_home_device_serials_reports_redacted_target_match(self):
+        summary = self.hub_a1.summarize_app_home_device_serials(
+            TEST_HUB_SERIAL,
+            [
+                {"sn": TEST_APEX_SERIAL, "model": "FP"},
+                {"sn": TEST_HUB_SERIAL, "model": "HA1"},
+            ],
+        )
+
+        self.assertIn("home_devices=2", summary)
+        self.assertIn("matches=1", summary)
+        self.assertIn("HA1:len=18", summary)
+        self.assertNotIn(TEST_HUB_SERIAL, summary)
+        self.assertNotIn(TEST_APEX_SERIAL, summary)
+
+    def test_build_hub_a1_product_data_falls_back_to_serial_name(self):
+        product = self.hub_a1.build_hub_a1_product_data(
+            TEST_HUB_SERIAL,
+            app_device={"model": "HA1"},
+            realtime={},
+            last_alive={},
+        )
+
+        self.assertEqual(product["name"], TEST_HUB_SERIAL)
+        self.assertEqual(product["online"], "0")
+        self.assertEqual(product["stateList"][0]["fnCode"], "onLine")
+
+    def test_has_hub_a1_telemetry_detects_fallback_payloads(self):
+        self.assertFalse(
+            self.hub_a1.has_hub_a1_telemetry(
+                realtime={},
+                last_alive={},
+                battery_details=[],
+                pv_details=[],
+                load_details=[],
+                grid_details=[],
+            )
+        )
+        self.assertTrue(
+            self.hub_a1.has_hub_a1_telemetry(
+                realtime={"batterySoc": "9"},
+                last_alive={},
+                battery_details=[],
+                pv_details=[],
+                load_details=[],
+                grid_details=[],
+            )
+        )
+        self.assertFalse(
+            self.hub_a1.has_hub_a1_telemetry(
+                realtime={},
+                last_alive={},
+                battery_details=[],
+                pv_details=[{"power": "0", "voltage": "0"}],
+                load_details=[],
+                grid_details=[],
+            )
+        )
+        self.assertTrue(
+            self.hub_a1.has_hub_a1_telemetry(
+                realtime={},
+                last_alive={"acSwitch": "1"},
+                battery_details=[],
+                pv_details=[],
+                load_details=[],
+                grid_details=[],
+            )
+        )
+
+    def test_describe_hub_a1_lookup_response_avoids_identifiers(self):
+        class Response:
+            msgCode = -2
+            code = -2
+            message = "Invalid serial TEST-HUB-A1-SERIAL"
+            data = None
+
+        description = self.hub_a1.describe_hub_a1_lookup_response(Response())
+
+        self.assertIn("msgCode=-2", description)
+        self.assertIn("code=-2", description)
+        self.assertIn("message=Invalid serial <redacted>", description)
+        self.assertNotIn(TEST_HUB_SERIAL, description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_refresh_contract.py
+++ b/tests/test_runtime_refresh_contract.py
@@ -1,0 +1,31 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+class RuntimeRefreshContractTests(unittest.TestCase):
+    def test_integration_registers_periodic_device_refresh(self):
+        init_source = (ROOT / "custom_components" / "bluetti" / "__init__.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("async_track_time_interval", init_source)
+        self.assertIn("timedelta(seconds=60)", init_source)
+        self.assertIn("refresh_unsub", init_source)
+        self.assertIn("await device.async_update()", init_source)
+        self.assertIn("BLUETTI periodic runtime state summary", init_source)
+        self.assertIn("__LOGGER__.isEnabledFor(logging.DEBUG)", init_source)
+
+    def test_unload_cancels_periodic_device_refresh(self):
+        init_source = (ROOT / "custom_components" / "bluetti" / "__init__.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('data.get("refresh_unsub")', init_source)
+        self.assertIn("refresh_unsub()", init_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unify_response.py
+++ b/tests/test_unify_response.py
@@ -1,0 +1,45 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "bluetti"
+    / "api"
+    / "unify_response.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("unify_response", MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError("unify_response module is missing")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class UnifyResponseTests(unittest.TestCase):
+    def setUp(self):
+        self.unify_response = load_module()
+
+    def test_preserves_optional_message_and_code_fields(self):
+        response = self.unify_response.UnifyResponse[dict].model_validate(
+            {
+                "msgId": "message-id",
+                "msgCode": -2,
+                "code": -2,
+                "message": "The parameter deviceSn can not be empty.",
+                "data": None,
+            }
+        )
+
+        self.assertEqual(response.msgCode, -2)
+        self.assertEqual(response.code, -2)
+        self.assertEqual(response.message, "The parameter deviceSn can not be empty.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bluetti_capture.py
+++ b/tools/bluetti_capture.py
@@ -1,0 +1,737 @@
+#!/usr/bin/env python3
+"""Capture BLUETTI device payloads through a local OAuth browser flow."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import json
+import os
+import secrets
+import select
+import socketserver
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SSO_BASE = "https://sso.bluettipower.com"
+GATEWAY_BASE = "https://gw.bluettipower.com"
+AUTHORIZE_PATH = "/oauth2/grant"
+TOKEN_PATH = "/oauth2/token"
+DEVICES_PATH = "/api/bluiotdata/ha/v1/devices"
+DEVICE_STATES_PATH = "/api/bluiotdata/ha/v1/deviceStates"
+KNOWN_READ_PROBE_PATHS = [
+    "/api/blusmartprod/user/space/v1/getSpaceDeviceList",
+    "/api/blusmartprod/device/group/v1/homeDevices",
+    "/api/blusmartprod/device/group/v1/findDevicePage",
+    "/api/blusmartprod/device/scene/v1/getAeccBindDeviceList",
+]
+KNOWN_SERIAL_READ_PROBE_TEMPLATES = [
+    "/api/bluiotdata/aecc/v1/getDeviceRealTimeData?{param}={serial}",
+    "/api/bluiotdata/aecc/v1/getDeviceBatteryDetailData?{param}={serial}",
+    "/api/bluiotdata/aecc/v1/getDevicePvDetailData?{param}={serial}",
+    "/api/bluiotdata/aecc/v1/getDeviceLoadDetailData?{param}={serial}",
+    "/api/bluiotdata/aecc/v1/getDeviceGridDetailData?{param}={serial}",
+    "/api/bluiotdata/realtime/v1/getDeviceLastAlive?{param}={serial}",
+    "/api/blusmartprod/aecc/workMode/v1/getWorkMode?{param}={serial}",
+    "/api/blusmartprod/aecc/advancedSetting/v1/getSettings?{param}={serial}",
+    "/api/blusmartprod/aecc/command/v1/querySystemPowerData?{param}={serial}",
+    "/api/blusmartprod/device/group/v1/findParallelDevice?{param}={serial}",
+    "/api/blusmartprod/device/basic/v1/findDeviceByBluetooth?{param}={serial}",
+    "/api/blusmartprod/device/basic/v1/deviceRemoteSearch?{param}={serial}",
+]
+KNOWN_SERIAL_PARAM_NAMES = ["sn", "deviceSn", "deviceSN", "deviceId"]
+KNOWN_SERIAL_POST_PROBE_PATHS = [
+    "/api/bluiotdata/aecc/v1/getDeviceRealTimeData",
+    "/api/bluiotdata/aecc/v1/getDeviceBatteryDetailData",
+    "/api/bluiotdata/aecc/v1/getDevicePvDetailData",
+    "/api/bluiotdata/aecc/v1/getDeviceLoadDetailData",
+    "/api/bluiotdata/aecc/v1/getDeviceGridDetailData",
+    "/api/bluiotdata/realtime/v1/getDeviceLastAlive",
+    "/api/blusmartprod/aecc/workMode/v1/getWorkMode",
+    "/api/blusmartprod/aecc/advancedSetting/v1/getSettings",
+    "/api/blusmartprod/aecc/command/v1/querySystemPowerData",
+]
+KNOWN_SERIAL_POST_PARAM_NAMES = ["deviceSn", "sn", "deviceSN", "deviceId"]
+
+DEFAULT_CLIENT_ID = "HomeAssistant"
+DEFAULT_CLIENT_SECRET = "SG9tZUFzc2lzdGFudA=="
+DEFAULT_CALLBACK_HOST = "127.0.0.1"
+DEFAULT_CALLBACK_PORT = 8765
+DEFAULT_CALLBACK_PATH = "/callback"
+DEFAULT_OAUTH_URL_FILE = "artifacts/bluetti-captures/oauth-url.txt"
+
+SENSITIVE_KEYS = {
+    "access_token",
+    "authorization",
+    "client_secret",
+    "code",
+    "cookie",
+    "id_token",
+    "password",
+    "refresh_token",
+    "set-cookie",
+    "token",
+}
+SERIAL_KEYS = {
+    "addressid",
+    "boardsn",
+    "bluetoothmac",
+    "deviceid",
+    "devicesn",
+    "mac",
+    "macaddress",
+    "masterdevicesn",
+    "messn",
+    "rfidtid",
+    "serial",
+    "serialno",
+    "serialnumber",
+    "sn",
+    "subsn",
+    "userid",
+}
+DEVICE_NAME_KEYS = {"device_name", "devicename", "nickname", "productname"}
+
+
+def stable_hash(value: Any) -> str:
+    """Return a deterministic short hash for correlating redacted identifiers."""
+    digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:16]}"
+
+
+def looks_like_serial_key(value: Any) -> bool:
+    """Return true for object keys that look like device serial numbers."""
+    if not isinstance(value, str):
+        return False
+    if value.startswith("sha256:"):
+        return False
+    if len(value) < 8 or len(value) > 64:
+        return False
+    has_digit = any(ch.isdigit() for ch in value)
+    has_alpha = any(ch.isalpha() for ch in value)
+    return has_digit and has_alpha and value.replace("-", "").replace("_", "").isalnum()
+
+
+def redact_identifier_text(value: str) -> str:
+    """Redact sensitive values embedded inside URL-like dict keys."""
+    if "?" not in value:
+        return value
+
+    prefix = ""
+    url_text = value
+    if value.startswith(("GET ", "POST ")):
+        prefix, url_text = value.split(" ", 1)
+        prefix = f"{prefix} "
+
+    parsed = urllib.parse.urlsplit(url_text)
+    if not parsed.query:
+        return value
+
+    changed = False
+    query_pairs: list[tuple[str, str]] = []
+    for key, item in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True):
+        normalized = key.lower().replace("-", "_")
+        if normalized in SENSITIVE_KEYS:
+            query_pairs.append((key, "<redacted>"))
+            changed = True
+        elif normalized in SERIAL_KEYS:
+            query_pairs.append((key, stable_hash(item)))
+            changed = True
+        else:
+            query_pairs.append((key, item))
+
+    if not changed:
+        return value
+
+    redacted_query = urllib.parse.urlencode(query_pairs)
+    redacted_url = urllib.parse.urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, redacted_query, parsed.fragment)
+    )
+    return f"{prefix}{redacted_url}"
+
+
+def redact_payload(value: Any, *, _inside_device: bool = False) -> Any:
+    """Return a copy of a BLUETTI payload with secrets and device IDs redacted."""
+    if isinstance(value, list):
+        return [redact_payload(item, _inside_device=_inside_device) for item in value]
+
+    if not isinstance(value, dict):
+        return value
+
+    lower_keys = {str(key).lower() for key in value}
+    is_device = _inside_device or bool(lower_keys & SERIAL_KEYS)
+    redacted: dict[str, Any] = {}
+
+    for key, item in value.items():
+        key_text = str(key)
+        key_lower = key_text.lower()
+        normalized = key_lower.replace("-", "_")
+        output_key = stable_hash(key_text) if looks_like_serial_key(key_text) else redact_identifier_text(key_text)
+
+        if normalized in SENSITIVE_KEYS or key_lower in SENSITIVE_KEYS:
+            redacted[output_key] = "<redacted>"
+        elif normalized in SERIAL_KEYS or key_lower in SERIAL_KEYS:
+            redacted[output_key] = stable_hash(item)
+        elif key_lower == "name" and is_device:
+            redacted[output_key] = "<redacted-name>"
+        elif normalized in DEVICE_NAME_KEYS:
+            redacted[output_key] = "<redacted-name>"
+        else:
+            redacted[output_key] = redact_payload(item, _inside_device=is_device)
+
+    return redacted
+
+
+def value_shape(value: Any) -> str:
+    """Describe a function value without exposing the value itself."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, str):
+        if value == "":
+            return "empty-string"
+        try:
+            float(value)
+        except ValueError:
+            return "string"
+        return "numeric-string"
+    return type(value).__name__
+
+
+def _response_data(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, dict) and isinstance(response.get("data"), list):
+        return response["data"]
+    return []
+
+
+def _first_state_record(state_response: Any, serial: str) -> dict[str, Any]:
+    for record in _response_data(state_response):
+        if isinstance(record, dict) and record.get("sn") == serial:
+            return record
+    data = _response_data(state_response)
+    if data and isinstance(data[0], dict):
+        return data[0]
+    return {}
+
+
+def _state_records(state_response: Any) -> list[dict[str, Any]]:
+    return [record for record in _response_data(state_response) if isinstance(record, dict)]
+
+
+def _summarize_device(
+    serial: str,
+    device: dict[str, Any],
+    state_response: Any,
+    *,
+    in_devices_response: bool,
+) -> dict[str, Any]:
+    state_record = _first_state_record(state_response, serial)
+    state_list = state_record.get("stateList") or device.get("stateList") or []
+    functions = []
+
+    for state in state_list:
+        if not isinstance(state, dict):
+            continue
+        functions.append(
+            {
+                "fnCode": state.get("fnCode"),
+                "fnName": state.get("fnName") or "",
+                "fnType": state.get("fnType"),
+                "value_shape": value_shape(state.get("fnValue")),
+                "sensorInfo": state.get("sensorInfo") or {},
+                "supportModeValues": state.get("supportModeValues") or [],
+            }
+        )
+
+    state_msg_code = state_response.get("msgCode") if isinstance(state_response, dict) else None
+    return {
+        "serial_hash": stable_hash(serial),
+        "source": "devices" if in_devices_response else "deviceStates",
+        "in_devices_response": in_devices_response,
+        "model": state_record.get("model") or device.get("model"),
+        "online": state_record.get("online") or device.get("online"),
+        "isBindByCurUser": state_record.get("isBindByCurUser") or device.get("isBindByCurUser"),
+        "state_response_msgCode": state_msg_code,
+        "state_count": len(functions),
+        "function_types": _count_by_key(functions, "fnType"),
+        "functions": functions,
+    }
+
+
+def summarize_capture(capture: dict[str, Any]) -> dict[str, Any]:
+    """Extract device/function descriptors needed to implement support."""
+    devices = _response_data(capture.get("devices"))
+    states_by_serial = capture.get("device_states", {})
+    summary_devices: list[dict[str, Any]] = []
+    seen_serials: set[str] = set()
+
+    for device in devices:
+        if not isinstance(device, dict):
+            continue
+
+        serial = str(device.get("sn", ""))
+        seen_serials.add(serial)
+        summary_devices.append(_summarize_device(serial, device, states_by_serial.get(serial), in_devices_response=True))
+
+    if isinstance(states_by_serial, dict):
+        for serial, state_response in states_by_serial.items():
+            serial = str(serial)
+            if serial in seen_serials:
+                continue
+            records = _state_records(state_response)
+            device = records[0] if records else {"sn": serial}
+            summary_devices.append(_summarize_device(serial, device, state_response, in_devices_response=False))
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "device_count": len(summary_devices),
+        "devices": summary_devices,
+    }
+
+
+def _count_by_key(items: list[dict[str, Any]], key: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        label = str(item.get(key) or "unknown")
+        counts[label] = counts.get(label, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+class OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Handle one local OAuth redirect without logging request details."""
+
+    server: "OAuthCallbackServer"
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        self.server.oauth_result = {
+            "path": parsed.path,
+            "code": params.get("code", [""])[0],
+            "state": params.get("state", [""])[0],
+            "error": params.get("error", [""])[0],
+        }
+
+        body = (
+            "<html><body><h1>BLUETTI capture received</h1>"
+            "<p>You can close this tab and return to the terminal.</p></body></html>"
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+
+class OAuthCallbackServer(http.server.HTTPServer):
+    oauth_result: dict[str, str] | None = None
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = str(host)
+        self.server_port = int(port)
+
+
+def build_authorize_url(client_id: str, redirect_uri: str, state: str) -> str:
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": state,
+    }
+    return f"{SSO_BASE}{AUTHORIZE_PATH}?{urllib.parse.urlencode(params)}"
+
+
+def wait_for_oauth_code(
+    host: str,
+    port: int,
+    path: str,
+    client_id: str,
+    timeout: int,
+    open_browser: bool,
+    oauth_url_file: Path | None = None,
+) -> tuple[str, str]:
+    redirect_uri = f"http://{host}:{port}{path}"
+    state = secrets.token_urlsafe(24)
+    authorize_url = build_authorize_url(client_id, redirect_uri, state)
+
+    server = OAuthCallbackServer((host, port), OAuthCallbackHandler)
+
+    if oauth_url_file is not None:
+        oauth_url_file.parent.mkdir(parents=True, exist_ok=True)
+        oauth_url_file.write_text(authorize_url + "\n", encoding="utf-8")
+
+    print("Open this BLUETTI OAuth URL if your browser does not open automatically:", flush=True)
+    print(authorize_url, flush=True)
+    if open_browser:
+        webbrowser.open(authorize_url)
+
+    deadline = time.monotonic() + timeout
+    try:
+        while server.oauth_result is None and time.monotonic() < deadline:
+            remaining = max(0.0, min(0.2, deadline - time.monotonic()))
+            ready, _, _ = select.select([server.socket], [], [], remaining)
+            if ready:
+                server.handle_request()
+    finally:
+        server.server_close()
+
+    if server.oauth_result is None:
+        raise RuntimeError("Timed out waiting for BLUETTI OAuth callback")
+    if not server.oauth_result:
+        raise RuntimeError("OAuth callback did not return a result")
+    if server.oauth_result.get("error"):
+        raise RuntimeError(f"OAuth returned error: {server.oauth_result['error']}")
+    if server.oauth_result.get("path") != path:
+        raise RuntimeError("OAuth callback path did not match the expected path")
+    if server.oauth_result.get("state") != state:
+        raise RuntimeError("OAuth state mismatch")
+    code = server.oauth_result.get("code")
+    if not code:
+        raise RuntimeError("OAuth callback did not include a code")
+    return code, redirect_uri
+
+
+def exchange_code_for_token(code: str, redirect_uri: str, client_id: str, client_secret: str) -> dict[str, Any]:
+    form = urllib.parse.urlencode(
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{SSO_BASE}{TOKEN_PATH}",
+        data=form,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    return request_json(request)
+
+
+def get_json(path: str, access_token: str, params: dict[str, str] | None = None) -> dict[str, Any]:
+    url = f"{GATEWAY_BASE}{path}"
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    request = urllib.request.Request(url, headers={"Authorization": access_token})
+    return request_json(request)
+
+
+def post_json(path: str, access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    url = f"{GATEWAY_BASE}{path}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": access_token,
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    return request_json(request)
+
+
+def request_json(request: urllib.request.Request) -> dict[str, Any]:
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        redacted = redact_payload({"status": exc.code, "body": body[:500]})
+        raise RuntimeError(f"BLUETTI HTTP error: {json.dumps(redacted)}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"BLUETTI request failed: {exc.reason}") from exc
+
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("BLUETTI response was not valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError("BLUETTI response JSON was not an object")
+    return parsed
+
+
+def capture_devices(
+    access_token: str,
+    extra_serials: list[str] | None = None,
+    probe_get_paths: list[str] | None = None,
+    probe_post_requests: list[tuple[str, dict[str, Any]]] | None = None,
+    getter: Any = get_json,
+    poster: Any = post_json,
+) -> dict[str, Any]:
+    devices = getter(DEVICES_PATH, access_token)
+    device_states: dict[str, Any] = {}
+    probes: dict[str, Any] = {}
+    serials: list[str] = []
+
+    for device in _response_data(devices):
+        serial = device.get("sn") if isinstance(device, dict) else None
+        if serial:
+            serials.append(str(serial))
+
+    for serial in extra_serials or []:
+        serial = serial.strip()
+        if serial and serial not in serials:
+            serials.append(serial)
+
+    for serial in serials:
+        device_states[serial] = getter(DEVICE_STATES_PATH, access_token, {"sns": serial})
+
+    for path in probe_get_paths or []:
+        normalized_path = normalize_probe_path(path)
+        try:
+            probes[normalized_path] = getter(normalized_path, access_token)
+        except Exception as exc:  # noqa: BLE001 - preserve exploratory probe failures in capture artifacts.
+            probes[normalized_path] = {
+                "ok": False,
+                "error": str(exc),
+            }
+
+    for path, payload in probe_post_requests or []:
+        normalized_path = normalize_probe_path(path)
+        probe_key = format_probe_request_key("POST", normalized_path, payload)
+        try:
+            probes[probe_key] = {
+                "method": "POST",
+                "path": normalized_path,
+                "request": {"json": payload},
+                "response": poster(normalized_path, access_token, payload),
+            }
+        except Exception as exc:  # noqa: BLE001 - preserve exploratory probe failures in capture artifacts.
+            probes[probe_key] = {
+                "ok": False,
+                "method": "POST",
+                "path": normalized_path,
+                "request": {"json": payload},
+                "error": str(exc),
+            }
+
+    return {"devices": devices, "device_states": device_states, "probes": probes}
+
+
+def format_probe_request_key(method: str, path: str, payload: dict[str, Any] | None = None) -> str:
+    if not payload:
+        return f"{method.upper()} {path}"
+
+    parts = []
+    for key, value in sorted(payload.items()):
+        normalized = str(key).lower().replace("-", "_")
+        if normalized in SENSITIVE_KEYS:
+            display_value = "<redacted>"
+        elif normalized in SERIAL_KEYS:
+            display_value = stable_hash(value)
+        elif isinstance(value, str | int | float | bool) or value is None:
+            display_value = str(value)
+        else:
+            display_value = value_shape(value)
+        parts.append(f"{key}={display_value}")
+    return f"{method.upper()} {path} {'&'.join(parts)}"
+
+
+def normalize_probe_path(path: str) -> str:
+    path = path.strip()
+    if not path:
+        raise ValueError("Probe path cannot be empty")
+    if path.startswith("https://gw.bluettipower.com"):
+        parsed = urllib.parse.urlparse(path)
+        path = parsed.path
+        if parsed.query:
+            path = f"{path}?{parsed.query}"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    if not path.startswith("/api/"):
+        raise ValueError("Probe path must be a BLUETTI /api/ path")
+    return path
+
+
+def write_capture(capture: dict[str, Any], output_root: Path, include_raw_private: bool) -> Path:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = output_root / timestamp
+    output_dir.mkdir(parents=True, exist_ok=False)
+
+    summary = summarize_capture(capture)
+    redacted = redact_payload(capture)
+    _write_json(output_dir / "summary.json", summary)
+    _write_json(output_dir / "redacted.json", redacted)
+    if include_raw_private:
+        _write_json(output_dir / "raw.private.json", capture)
+    return output_dir
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture BLUETTI OAuth device payloads locally.")
+    parser.add_argument("--output-dir", default="artifacts/bluetti-captures")
+    parser.add_argument("--callback-host", default=DEFAULT_CALLBACK_HOST)
+    parser.add_argument("--callback-port", type=int, default=DEFAULT_CALLBACK_PORT)
+    parser.add_argument("--callback-path", default=DEFAULT_CALLBACK_PATH)
+    parser.add_argument("--oauth-url-file", default=DEFAULT_OAUTH_URL_FILE)
+    parser.add_argument("--client-id", default=os.environ.get("BLUETTI_CLIENT_ID", DEFAULT_CLIENT_ID))
+    parser.add_argument("--client-secret", default=os.environ.get("BLUETTI_CLIENT_SECRET", DEFAULT_CLIENT_SECRET))
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument(
+        "--extra-sn",
+        action="append",
+        default=[],
+        help="Also query deviceStates for this serial even if /devices omits it. Repeatable.",
+    )
+    parser.add_argument(
+        "--extra-sn-file",
+        help="File containing additional serial numbers to query, one per line.",
+    )
+    parser.add_argument(
+        "--probe-get",
+        action="append",
+        default=[],
+        help="Also capture a raw read-only GET response from this BLUETTI /api/ path. Repeatable.",
+    )
+    parser.add_argument(
+        "--probe-post-json",
+        action="append",
+        default=[],
+        help=(
+            "Also capture a raw read-only POST JSON response from this BLUETTI /api/ path, "
+            "formatted as /api/path={\"deviceSn\":\"...\"}. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--probe-known-read",
+        action="store_true",
+        help="Capture known read-only BLUETTI app/device endpoints that may list devices omitted by the HA endpoint.",
+    )
+    parser.add_argument("--no-browser", action="store_true", help="Print the OAuth URL without opening a browser.")
+    parser.add_argument(
+        "--raw-private",
+        action="store_true",
+        help="Also write raw.private.json. This file may contain serial numbers and device names.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_extra_serials(args: argparse.Namespace) -> list[str]:
+    serials = list(args.extra_sn or [])
+    if args.extra_sn_file:
+        path = Path(args.extra_sn_file)
+        for line in path.read_text(encoding="utf-8").splitlines():
+            value = line.strip()
+            if value and not value.startswith("#"):
+                serials.append(value)
+    return serials
+
+
+def load_probe_paths(args: argparse.Namespace) -> list[str]:
+    paths = list(args.probe_get or [])
+    if args.probe_known_read:
+        paths.extend(KNOWN_READ_PROBE_PATHS)
+        for serial in load_extra_serials(args):
+            encoded_serial = urllib.parse.quote(serial, safe="")
+            for template in KNOWN_SERIAL_READ_PROBE_TEMPLATES:
+                for param in KNOWN_SERIAL_PARAM_NAMES:
+                    paths.append(template.format(param=param, serial=encoded_serial))
+
+    normalized: list[str] = []
+    for path in paths:
+        probe_path = normalize_probe_path(path)
+        if probe_path not in normalized:
+            normalized.append(probe_path)
+    return normalized
+
+
+def load_probe_post_requests(args: argparse.Namespace) -> list[tuple[str, dict[str, Any]]]:
+    requests: list[tuple[str, dict[str, Any]]] = []
+
+    for value in args.probe_post_json or []:
+        requests.append(parse_probe_post_json(value))
+
+    if args.probe_known_read:
+        for serial in load_extra_serials(args):
+            for path in KNOWN_SERIAL_POST_PROBE_PATHS:
+                for param in KNOWN_SERIAL_POST_PARAM_NAMES:
+                    requests.append((path, {param: serial}))
+
+    normalized: list[tuple[str, dict[str, Any]]] = []
+    seen: set[str] = set()
+    for path, payload in requests:
+        normalized_path = normalize_probe_path(path)
+        key = json.dumps([normalized_path, payload], sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            normalized.append((normalized_path, payload))
+    return normalized
+
+
+def parse_probe_post_json(value: str) -> tuple[str, dict[str, Any]]:
+    if "=" not in value:
+        raise ValueError("--probe-post-json must be formatted as /api/path={...}")
+    path, payload_text = value.split("=", 1)
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError("--probe-post-json payload must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("--probe-post-json payload must be a JSON object")
+    return normalize_probe_path(path), payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    code, redirect_uri = wait_for_oauth_code(
+        args.callback_host,
+        args.callback_port,
+        args.callback_path,
+        args.client_id,
+        args.timeout,
+        not args.no_browser,
+        Path(args.oauth_url_file) if args.oauth_url_file else None,
+    )
+    token = exchange_code_for_token(code, redirect_uri, args.client_id, args.client_secret)
+    access_token = token.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise RuntimeError("Token response did not include access_token")
+
+    capture = capture_devices(
+        access_token,
+        load_extra_serials(args),
+        load_probe_paths(args),
+        load_probe_post_requests(args),
+    )
+    output_dir = write_capture(capture, Path(args.output_dir), args.raw_private)
+    summary = summarize_capture(capture)
+    print(f"Capture written to: {output_dir}")
+    print(f"Devices captured: {summary['device_count']}")
+    print("Share summary.json and redacted.json for implementation work.")
+    if args.raw_private:
+        print("raw.private.json was written by explicit request; do not share it publicly.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds BLUETTI Apex-family / Hub A1 support on top of the existing Home Assistant cloud integration.

- Adds a read-only BLUETTI app API capture harness with redacted output for unsupported-device discovery.
- Adds manual Hub A1 serial configuration and startup cleanup for invalid cached Hub A1 entries.
- Builds a Home Assistant `UserProduct` for Hub A1 from read-only app/realtime/lastAlive/detail endpoints.
- Adds Hub A1 sensors for the values that proved meaningful in live account data, while keeping untrusted mirrored/placeholder fields out of the entity set.
- Adds app-side state overrides for Apex-family devices that are stale or incomplete in the existing Home Assistant APIs.
- Fixes non-HA1 app pack-total energy scaling so centi-kWh counters are exposed as kWh.
- Keeps runtime/payload diagnostic summaries available only when debug logging is enabled; real refresh/load failures remain warning-level.
- Adds regression coverage for Hub A1 mapping, runtime refresh, debug-only diagnostics, capture redaction, and response parsing.

## Notes

- Hub A1 serial entry remains manual. The observed account APIs did not prove a reliable automatic Hub A1 serial discovery path from a friendly-name-only config.
- Hub A1 SOH, meter total energy, and mirrored discharge total are intentionally not exposed because the captured/live data showed those fields were either implausible, always zero, or duplicates of the charge counter.
- The capture tool writes implementation-safe `summary.json` and `redacted.json`; private raw payload export is opt-in and documented as not for public sharing.
- This PR intentionally avoids unrelated repository packaging/documentation churn: no `.gitignore`, README, HACS metadata, manifest metadata, or local release-note changes are included.

## Verification

- `python3 -m unittest discover -s tests` - 50 tests passed.
- `python3 -m compileall custom_components/bluetti tests` passed.
- `git diff --check` passed.
- PR branch is one squashed commit on top of `upstream/main`.
