### PR TITLE
fix: critical cloud/OAuth/websocket reliability bugs

### DIFF
--- a/custom_components/bluetti/__init__.py
+++ b/custom_components/bluetti/__init__.py
@@ -2,11 +2,11 @@
 # from __future__ import annotations
 
 import logging
-import asyncio
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_entry_oauth2_flow, device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import storage
@@ -35,43 +35,46 @@ type BluettiConfigEntry = ConfigEntry[BluettiData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> bool:
-    await APPLICATION_PROFILE.load_config(hass)
+    try:
+        await APPLICATION_PROFILE.load_config(hass)
 
-    enabled_devices = entry.options.get("devices", [])
-    all_products_data: list[dict] = entry.data.get("products", [])
-    all_products: list[UserProduct] = [
-        UserProduct.model_validate(p) if isinstance(p, dict) else p
-        for p in all_products_data
-    ]
-    
-    """OAUTH2: get the access token."""
-    implementation = (
-        await config_entry_oauth2_flow.async_get_config_entry_implementation(
-            hass, entry
+        enabled_devices = entry.options.get("devices", [])
+        all_products_data: list[dict] = entry.data.get("products", [])
+        all_products: list[UserProduct] = [
+            UserProduct.model_validate(p) if isinstance(p, dict) else p
+            for p in all_products_data
+        ]
+
+        """OAUTH2: get the access token."""
+        implementation = (
+            await config_entry_oauth2_flow.async_get_config_entry_implementation(
+                hass, entry
+            )
         )
-    )
-    __LOGGER__.debug("OAuth implementation is: %s", implementation.__class__)
+        __LOGGER__.debug("OAuth implementation is: %s", implementation.__class__)
 
-    httpSession = async_get_clientsession(hass)
-    oAuth2Session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
+        httpSession = async_get_clientsession(hass)
+        oAuth2Session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
 
-    # If using a requests-based API lib
-    # entry.runtime_data = ConfigEntryAuth(hass, oAuth2Session)
+        # If using a requests-based API lib
+        # entry.runtime_data = ConfigEntryAuth(hass, oAuth2Session)
 
-    # If using an aiohttp-based API lib
-    entry.runtime_data = AsyncConfigEntryAuth(
-        httpSession, oAuth2Session
-    )
+        # If using an aiohttp-based API lib
+        entry.runtime_data = AsyncConfigEntryAuth(
+            httpSession, oAuth2Session
+        )
 
-    authTokenRefresh = AuthTokenRefresh(hass,entry,oAuth2Session)
-    authTokenRefresh.start_token_check()
-        
-    # await oAuth2Session.async_ensure_token_valid()
-    access_token = oAuth2Session.token["access_token"]
-    product_client = ProductClient(httpSession, access_token,hass)
-    # products = await product_client.get_user_products()
-    # print(products.data[0].__class__)
-    # print(products.data)
+        authTokenRefresh = AuthTokenRefresh(hass,entry,oAuth2Session)
+        authTokenRefresh.start_token_check()
+
+        # await oAuth2Session.async_ensure_token_valid()
+        access_token = oAuth2Session.token["access_token"]
+        product_client = ProductClient(httpSession, access_token,hass)
+        # products = await product_client.get_user_products()
+        # print(products.data[0].__class__)
+        # print(products.data)
+    except Exception as err:
+        raise ConfigEntryNotReady(f"BLUETTI setup failed: {err}") from err
 
     selected_products = [p for p in all_products if p.sn in enabled_devices]
 
@@ -98,12 +101,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> b
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     for device in bluetti_devices.devices:
-        asyncio.run_coroutine_threadsafe(device.async_update(), hass.loop)
+        await device.async_update()
 
     # async def _after_start(event):
     #     # print(event)
     #     for device in bluetti_devices.devices:
-    #         asyncio.run_coroutine_threadsafe(device.async_update(), hass.loop)
+    #         await device.async_update()
 
     # hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _after_start)
     __LOGGER__.info('bluetti init ok')
@@ -118,7 +121,15 @@ def web_socket_message_handler(message: str):
 # TODO Update entry annotation
 async def async_unload_entry(hass: HomeAssistant, entry: BluettiConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    unloaded = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    if unloaded:
+        data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if data and "stompClient" in data:
+            try:
+                data["stompClient"].disconnect()
+            except Exception as e:
+                __LOGGER__.warning("Error while disconnecting websocket: %s", e)
+    return unloaded
 
 async def async_remove_entry(hass, entry):
     """Handle removal of an entry."""

--- a/custom_components/bluetti/api/bluetti.py
+++ b/custom_components/bluetti/api/bluetti.py
@@ -48,7 +48,7 @@ class Bluetti(Generic[T]):
             method: Method,
             path: str,
             params: dict[str, Any] | None = None,
-            body: dict[str, Any] | None = {}
+            body: dict[str, Any] | None = None
     ) -> UnifyResponse[T] | str:
         """
         Send a request to the server.\n
@@ -95,7 +95,7 @@ class Bluetti(Generic[T]):
                 unify_response = TypeAdapter(UnifyResponse[responseType]).validate_python(data)
                 # self.logger.debug("<====== Server response body: %s", dumps(data, indent=4, ensure_ascii=False))
                 # print(repr(unify_response))
-                if data['code'] == 805:
+                if data.get('msgCode') == 805:
                     self._hass.bus.fire(EVENT_TOKEN_EXPIRED)
                     self.logger.info("token have expired")
                 return unify_response

--- a/custom_components/bluetti/api/product_client.py
+++ b/custom_components/bluetti/api/product_client.py
@@ -49,7 +49,7 @@ class ProductClient(Bluetti):
             params={'sns': sns}
         )
 
-    async def control_device(self, payload: str = None):
+    async def control_device(self, payload: dict = None):
         """
         控制设备
         """
@@ -59,7 +59,7 @@ class ProductClient(Bluetti):
             path="/api/bluiotdata/ha/v1/fulfillment",
             body=payload
         )
-    async def bind_devices(self, payload: str = None):
+    async def bind_devices(self, payload: dict = None):
         """
         bind devices
         """

--- a/custom_components/bluetti/api/websocket.py
+++ b/custom_components/bluetti/api/websocket.py
@@ -64,7 +64,15 @@ class StompClient(object):
         self.reconnect_delay = 1  # 初始重连延迟（秒）
         self.max_reconnect_delay = 30  # 最大重连延迟（秒）
         # Run until interruption to client or server terminates connection.
-        Thread(target=self.websocket.run_forever).start()
+        Thread(target=self._run_forever_safe, daemon=True, name="bluetti-ws").start()
+
+    def _run_forever_safe(self):
+        try:
+            self.websocket.run_forever()
+        except Exception:
+            __LOGGER__.exception("BLUETTI WebSocket thread crashed")
+            if self.running:
+                self.reconnect()
 
     def disconnect(self):
         self.running = False
@@ -164,7 +172,11 @@ class StompListener:
             server_send, server_receive = map(int, heartbeat.split(','))
             __LOGGER__.info(f"Server heartbeat configuration: send={server_send}, receive={server_receive}")
 
-            destination = "/ws-subscribe/user/" + frame.headers['user-name'] + "/notify"
+            user_name = frame.headers.get('user-name')
+            if not user_name:
+                __LOGGER__.error("CONNECTED frame missing 'user-name' header, cannot subscribe")
+                return
+            destination = f"/ws-subscribe/user/{user_name}/notify"
             self.__on_subscribe(ws, destination)
         elif frame.cmd == "MESSAGE":
             self.__callback(self.__handler, frame.body)
@@ -179,7 +191,7 @@ class StompListener:
           error(str): Error received.
 
         """
-        print("The Error is:- " , error)
+        __LOGGER__.error("The BLUETTI WebSocket raised an error: %s", error)
 
     def on_close(self, ws, close_status_code, close_msg):
         __LOGGER__.debug(f"WebSocket 断开连接。状态码: {close_status_code}, 消息: {close_msg}")

--- a/custom_components/bluetti/application_exception.py
+++ b/custom_components/bluetti/application_exception.py
@@ -1,4 +1,4 @@
-class ApplicationRuntimeException(BaseException):
+class ApplicationRuntimeException(Exception):
     """The runtime exception for BLUETTI integration"""
 
     message: str = "An unknown error has occurred."

--- a/custom_components/bluetti/const.py
+++ b/custom_components/bluetti/const.py
@@ -7,9 +7,6 @@ INTEGRATION_NAME: str = 'BLUETTI'
 EVENT_TOKEN_EXPIRED: str ="onTokenExpired"
 NOTIFY_ID_TOKEN_EXPIRED: str ="notifyTokenExpire"
 
-# TODO Update with your own urls
-BLUETTI_WSS_SERVER: str = "ws://local-gw.poweroak.ltd:18888/api/edgeiotgw/ws-coordination/websocket"
-
 class StringEnum(str, Enum):
     """String Enum define."""
 

--- a/custom_components/bluetti/manifest.json
+++ b/custom_components/bluetti/manifest.json
@@ -11,9 +11,9 @@
   ],
   "documentation": "https://www.home-assistant.io/integrations/bluetti",
   "homekit": {},
-  "iot_class": "local_polling",
+  "iot_class": "cloud_push",
   "quality_scale": "bronze",
-  "requirements": ["pydantic", "stomper","websocket-client"],
+  "requirements": ["pydantic>=2.0", "stomper>=0.4", "websocket-client>=1.6"],
   "ssdp": [],
   "zeroconf": []
 }

--- a/custom_components/bluetti/model/product.py
+++ b/custom_components/bluetti/model/product.py
@@ -1,9 +1,8 @@
-from dataclasses import dataclass
 from typing import Optional
 
 from pydantic import BaseModel
 
-@dataclass
+
 class UserProduct(BaseModel):
     """"""
     sn: str

--- a/custom_components/bluetti/models.py
+++ b/custom_components/bluetti/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 from typing import Callable, Optional, List
 import asyncio
-import random
 import json
 import logging
 
@@ -121,7 +120,7 @@ class BluettiDevice:
         # self._ws_manager = ws_manager
 
         # 创建一个定时任务轮询获取设备状态
-        self.async_update = Throttle(timedelta(microseconds=1))(self._async_update)
+        self.async_update = Throttle(timedelta(seconds=5))(self._async_update)
 
     def __repr__(self):
         return f"<BluettiDevice id={self.device_id} name={self.name}>"
@@ -181,16 +180,6 @@ class BluettiDevice:
         return 0
 
     @property
-    def battery_voltage(self) -> float:
-        # TODO
-        return round(random.random() * 3 + 10, 2)
-
-    @property
-    def illuminance(self) -> int:
-        # TODO
-        return random.randint(0, 500)
-
-    @property
     def throttle(self):
         return self._t
 
@@ -199,34 +188,36 @@ class BluettiDevice:
         return self._schedule_state
 
     async def _async_update(self):
-        api_client = self._api_client
+        try:
+            api_client = self._api_client
 
-        device_status = await api_client.get_device_status(self.device_id)
-        # print(device_status.data[0])
-        data = device_status.data[0]
+            device_status = await api_client.get_device_status(self.device_id)
+            if not device_status.data:
+                __LOGGER__.warning("Empty status response for device %s", self.device_id)
+                return
+            data = device_status.data[0]
 
-        # print(f'device_status: {data}')
+            sn = data.sn
+            if sn != self.device_id:
+                return
 
-        sn = data.sn
-        if sn != self.device_id:
-            return
-        
-        if data.isBindByCurUser == '0':
-            # unbind device
-            if not self._unbind_processed:
-                await self._handle_unbind()
-            
+            if data.isBindByCurUser == '0':
+                # unbind device
+                if not self._unbind_processed:
+                    await self._handle_unbind()
 
-        self.on_line = data.online
+            self.on_line = data.online
 
-        new_states = data.stateList
+            new_states = data.stateList
 
-        for s in new_states:
-            state_obj = self.get_state(s["fnCode"])
-            if state_obj:
-                state_obj.fn_value = s["fnValue"]
+            for s in new_states:
+                state_obj = self.get_state(s["fnCode"])
+                if state_obj:
+                    state_obj.fn_value = s["fnValue"]
 
-        await self.publish_updates()
+            await self.publish_updates()
+        except Exception:
+            __LOGGER__.exception("Failed to update device %s", self.device_id)
 
     async def _handle_unbind(self):
         """Handle device unbinding: Clean up the device, entity, and configuration, and display the notification."""
@@ -335,7 +326,7 @@ class BluettiDevice:
                     f"If this is a mistake, please re-add the device."
                 )
                 
-                persistent_notification.create(
+                persistent_notification.async_create(
                     hass,
                     title=notification_title,
                     message=notification_message,

--- a/custom_components/bluetti/oauth.py
+++ b/custom_components/bluetti/oauth.py
@@ -61,7 +61,7 @@ class OAuth2FlowHandler(config_entry_oauth2_flow.AbstractOAuth2FlowHandler, doma
                 # 合并产品数据（去重）
                 existing_product_sns = {p.get('sn') if isinstance(p, dict) else p.sn for p in existing_products}
                 new_products = [p for p in self._products if p.sn not in existing_product_sns]
-                merged_products = existing_products + [p.__dict__ if hasattr(p, '__dict__') else p for p in new_products]
+                merged_products = existing_products + [p.model_dump() if hasattr(p, 'model_dump') else p for p in new_products]
                 
                 # 更新现有条目
                 self.hass.config_entries.async_update_entry(
@@ -196,11 +196,12 @@ class AuthTokenRefresh:
             self.send_expired_notification()
         else:
             interval = timedelta(days=1)
-            async_track_time_interval(
+            unsub = async_track_time_interval(
                 self.hass,
                 self.async_check_token_expiry,  # 要执行的任务函数
                 interval       # 执行间隔
             )
+            self.entry.async_on_unload(unsub)
             __LOGGER__.info("token is valid after 24 hours to check again")
         self.hass.async_create_task(self.async_check_token_expiry())
         
@@ -241,7 +242,10 @@ class AuthTokenRefresh:
     # check token is in 7 day if in 7day refesh token
     async def async_check_token_expiry(self):
         __LOGGER__.info("check token is expired")
-        expire_timestamp = cast(float, self.oAuth2Session.token["expires_at"])
+        expire_timestamp = self.oAuth2Session.token.get("expires_at")
+        if expire_timestamp is None:
+            __LOGGER__.warning("No expires_at in token, skipping expiry check")
+            return
         current_timestamp = time.time()
         remain_timestamp = expire_timestamp - current_timestamp
         if remain_timestamp < 0:

--- a/custom_components/bluetti/profile/application_profile.py
+++ b/custom_components/bluetti/profile/application_profile.py
@@ -15,7 +15,7 @@ class ApplicationProfile:
     config: dict = {}
 
     def __init__(self, active=None):
-        self.__active = active or os.getenv("bluetti.profile.active", "").lower()
+        self.__active = active or os.getenv("BLUETTI_PROFILE_ACTIVE", "").lower()
         __LOGGER__.info("Setting up application profile: %s", "prod" if self.__active == "" else self.__active)
 
         if self.__active != "":
@@ -29,9 +29,15 @@ class ApplicationProfile:
         return hass.async_add_executor_job(self.__load_config)
 
     def __load_config(self):
-        with open(self.__configPath, "r") as file:
-            __yaml__ = yaml.safe_load(file)
-            __LOGGER__.info("Load profile " f"{self.__configFile} of `{INTEGRATION_NAME}` integration successfully.")
+        try:
+            with open(self.__configPath, "r") as file:
+                __yaml__ = yaml.safe_load(file)
+        except (OSError, yaml.YAMLError) as err:
+            __LOGGER__.error(
+                "Failed to load profile %s of `%s` integration: %s",
+                self.__configFile, INTEGRATION_NAME, err,
+            )
+            raise
 
+        __LOGGER__.info("Load profile " f"{self.__configFile} of `{INTEGRATION_NAME}` integration successfully.")
         self.config = __yaml__['bluetti']
-        # print(self.config)

--- a/custom_components/bluetti/select.py
+++ b/custom_components/bluetti/select.py
@@ -58,10 +58,10 @@ class BluettiSelect(SelectEntity):
         # 检查是否为只读（根据fn_code判断）
         self._readonly = state.fn_code == "InvWorkState"
 
-        # 如果只读，让 Home Assistant 前端显示为只读（灰掉）
+        # 如果只读，标记为诊断实体；保留 options 列表以避免 current_option 不在
+        # options 列表中时 Home Assistant 记录 "not in the list of available options" 警告
         if self._readonly:
-            self._attr_options = []  # 不显示可选项
-            self._attr_entity_category = EntityCategory.DIAGNOSTIC  # 可选，标记为非操作类实体
+            self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
         # print(f"注册设备: {device.name}, identifiers= {(DOMAIN, device.device_id)}")
 

--- a/custom_components/bluetti/sensor.py
+++ b/custom_components/bluetti/sensor.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TypedDict
 
 from homeassistant.const import PERCENTAGE
@@ -10,6 +11,8 @@ from . import BluettiConfigEntry
 from .const import DOMAIN
 from .models import BluettiData, BluettiDevice, BluettiState
 from .icon_config import get_icon_for_fn_code
+
+__LOGGER__ = logging.getLogger(__name__)
 
 # 映射 sensor 类
 # SENSOR_MAP = {
@@ -86,7 +89,13 @@ async def async_setup_entry(
         #         entities.append(BluettiBinarySensor(device, state, BINARY_SENSOR_MAP[state.fn_code]))
         for state in device.states:
             if state.fn_type == 'SENSOR' and state.sensor_info:
-                sensorClass = SENSOR_MAP[state.sensor_info['sensorType']]
+                sensorClass = SENSOR_MAP.get(state.sensor_info.get('sensorType'))
+                if sensorClass is None:
+                    __LOGGER__.warning(
+                        "Unknown sensor type '%s' for fn_code=%s, skipping",
+                        state.sensor_info.get('sensorType'), state.fn_code,
+                    )
+                    continue
                 meta: NamedSensorMetaInfo = {
                     "name": state.fn_name,
                     "unit": state.sensor_info["unit"] or sensorClass["unit"],

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+Fixes:
+- Fix the OAuth token-refresh timer leak that could accumulate duplicate timers on every reload, causing recurring forced re-logins.
+- Fix an unrecognized sensor type crashing the whole integration setup instead of just skipping that sensor.
+- Fix a blocking call, a websocket thread that could die silently without reconnecting, and several other reliability issues found during a full code review.
+
+
 # 1.0.2 2026-03-31
 New power station models have been supported:
 


### PR DESCRIPTION
## Summary

First of a series of 7 focused PRs, replacing the single large #124 (split per feedback on that
PR — see the linked comment there). This one is standalone and touches nothing beyond fixing
concrete, reported reliability bugs found during a full code review.

Fixes #109, fixes #110, fixes #112, fixes #115, closes #123.

## What's in here

- `ApplicationRuntimeException` now inherits from `Exception` instead of `BaseException` (existing
  `except Exception` blocks elsewhere in the codebase could never catch it).
- Fix the OAuth token-refresh timer leak by unsubscribing it via `entry.async_on_unload` (fixes
  #109, #110, #115 - the recurring forced re-logins with no error shown, and the OAuth Expired
  notification repeatedly coming back after reconfiguring).
- Guard access to `frame.headers['user-name']` in the STOMP client (fixes #112 - the cloud
  integration silently stopping updates after an OAuth failure with a `KeyError: 'user-name'`).
- Add a `SENSOR_MAP.get()` fallback so an unknown `sensorType` no longer aborts the whole platform
  setup.
- Remove the `battery_voltage`/`illuminance` properties that returned fake random values.
- Fix `data['code']` to `data.get('msgCode')` for REST-side token expiry detection.
- Reduce the `Throttle` window from 1 microsecond to 5 seconds.
- Replace the blocking `persistent_notification.create` call with `async_create`.
- Supervise the WebSocket thread (named, daemon, reconnects on crash) and replace `print()` with
  the logger. May also help with #94, #108, #91 (sensor data getting stuck / stopping updates
  after a while) - same class of bug (a dead/wedged connection with no recovery), but not
  confirmed against those specific reports.
- Add error handling in `_async_update` and raise `ConfigEntryNotReady` instead of failing
  silently during setup.
- Replace `asyncio.run_coroutine_threadsafe` with a direct `await`.
- Disconnect the websocket on entry unload, not just on removal.
- Drop the redundant `@dataclass` decorator on `UserProduct(BaseModel)` and use `model_dump()`
  when merging OAuth products.
- Correctly type API call payloads as `dict` instead of `str`.
- Fix the read-only select that triggered a Home Assistant warning.
- Set `iot_class` to `cloud_push` and pin dependency versions in the manifest.
- Clean up dead code (unencrypted `BLUETTI_WSS_SERVER`) and the non-conventional environment
  variable name.

## Testing

No automated test suite exists at this point in the stack (added in the next PR) - verified via
`py_compile` and live testing against a real BLUETTI account/device.