### PR TITLE
Fix recurring "OAuth Expired": daily token auto-refresh crashes on callback signature

### DIFF
--- a/custom_components/bluetti/manifest.json
+++ b/custom_components/bluetti/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "bluetti",
   "name": "BLUETTI",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "codeowners": [
     "@bluetti-official"
   ],

--- a/custom_components/bluetti/oauth.py
+++ b/custom_components/bluetti/oauth.py
@@ -239,7 +239,7 @@ class AuthTokenRefresh:
         )
 
     # check token is in 7 day if in 7day refesh token
-    async def async_check_token_expiry(self):
+    async def async_check_token_expiry(self, now=None):
         __LOGGER__.info("check token is expired")
         expire_timestamp = cast(float, self.oAuth2Session.token["expires_at"])
         current_timestamp = time.time()


### PR DESCRIPTION
## Problem

The daily token auto-refresh added in v1.0.2 (`AuthTokenRefresh`) crashes on **every** scheduled run, so the OAuth token is only ever refreshed once — at HA startup. Any instance left running past the token lifetime expires and forces a manual re-auth. This appears to be the root cause behind the cluster of "OAuth Expired" reports: #121, #115, #109, #81, #75, #71.

`start_token_check()` schedules the check with:

```python
async_track_time_interval(self.hass, self.async_check_token_expiry, timedelta(days=1))
```

`async_track_time_interval` invokes its callback with the current time — `action(now)` — but `async_check_token_expiry` only accepted `self`, so every scheduled run raises:

```
TypeError: AuthTokenRefresh.async_check_token_expiry() takes 1 positional argument but 2 were given
```

The one-shot `async_create_task(self.async_check_token_expiry())` at startup still works (no arg passed), which is why a refresh only ever happens at restart — masking the bug until the token finally expires.

## Fix

```diff
-    async def async_check_token_expiry(self):
+    async def async_check_token_expiry(self, now=None):
```

`now=None` lets the scheduled call pass its timestamp (which the method ignores) while the direct startup call still works. No behavior change beyond letting the daily refresh actually run.

## Testing

Reproduced and verified on Home Assistant 2026.8.3 (Python 3.14) with integration v1.0.2. Before: the daily job raised the `TypeError` on every run, and the token eventually expired into the recurring "OAuth Expired" state. After: the scheduled `async_check_token_expiry` runs cleanly, and the token refreshes within its 7-day window — no more re-auth prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
